### PR TITLE
feat: cnpg single cluster

### DIFF
--- a/kubernetes/apps/database/cnpg/app/externalsecret.yaml
+++ b/kubernetes/apps/database/cnpg/app/externalsecret.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name cnpg-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless-secret-store
+  target:
+    name: *name
+    template:
+      data:
+        username: "{{ .POSTGRES_SUPER_USER }}"
+        password: "{{ .POSTGRES_SUPER_PASS }}"
+        aws-access-key-id: "{{ .AWS_ACCESS_KEY_ID }}"
+        aws-secret-access-key: "{{ .AWS_SECRET_ACCESS_KEY }}"
+        AWS_CNPG_BUCKET: "{{ .AWS_CNPG_BUCKET }}"
+  dataFrom:
+    - extract:
+        key: /cnpg-operator
+    - extract:
+        key: /aws-creds

--- a/kubernetes/apps/database/cnpg/app/helmrelease.yaml
+++ b/kubernetes/apps/database/cnpg/app/helmrelease.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cnpg-operator
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: cloudnative-pg
+      version: 0.23.2
+      sourceRef:
+        kind: HelmRepository
+        name: cloudnative-pg
+        namespace: flux-system
+      interval: 15m
+  maxHistory: 2
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: false
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    crds:
+      create: true
+    replicaCount: 2
+    monitoring:
+      podMonitorEnabled: true
+      grafanaDashboard:
+        create: true

--- a/kubernetes/apps/database/cnpg/app/kustomization.yaml
+++ b/kubernetes/apps/database/cnpg/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/database/cnpg/cluster/cluster16.yaml
+++ b/kubernetes/apps/database/cnpg/cluster/cluster16.yaml
@@ -1,0 +1,66 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres16
+spec:
+  instances: 3
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: switchover
+  storage:
+    size: 20Gi
+    storageClass: openebs-hostpath
+  superuserSecret:
+    name: cnpg-secret
+  enableSuperuserAccess: true
+  postgresql:
+    parameters:
+      max_connections: '400'
+      shared_buffers: '512MB'
+    pg_hba:
+    - host all all 10.42.0.0/16 scram-sha-256
+  nodeMaintenanceWindow:
+    inProgress: false
+    reusePVC: true
+  resources:
+    requests:
+      cpu: 500m
+    limits:
+      memory: 4Gi
+  monitoring:
+    enablePodMonitor: true
+
+  backup:
+    retentionPolicy: 30d
+    barmanObjectStore: &barmanObjectStore
+      data:
+        compression: bzip2
+      wal:
+        compression: bzip2
+        maxParallel: 8
+      destinationPath: s3://${AWS_CNPG_BUCKET}/
+      endpointURL: https://${AWS_CNPG_BUCKET}.s3.us-east-1.amazonaws.com/
+      # Note: serverName version needs to be incremented
+      # when recovering from an existing cnpg cluster
+      serverName: &currentCluster postgres16-v1
+      s3Credentials:
+        accessKeyId:
+          name: cnpg-secret
+          key: aws-access-key-id
+        secretAccessKey:
+          name: cnpg-secret
+          key: aws-secret-access-key
+
+  # Note: previousCluster needs to be set to the name of the previous
+  # cluster when recovering from an existing cnpg cluster
+  # bootstrap:
+  #   recovery:
+  #     source: &previousCluster postgres16-v1
+  # Note: externalClusters is needed when recovering from an existing cnpg cluster
+  # externalClusters:
+  #   - name: *previousCluster
+  #     barmanObjectStore:
+  #       <<: *barmanObjectStore
+  #       serverName: *previousCluster

--- a/kubernetes/apps/database/cnpg/cluster/cluster16.yaml
+++ b/kubernetes/apps/database/cnpg/cluster/cluster16.yaml
@@ -10,7 +10,7 @@ spec:
   primaryUpdateStrategy: unsupervised
   primaryUpdateMethod: switchover
   storage:
-    size: 20Gi
+    size: 10Gi
     storageClass: openebs-hostpath
   superuserSecret:
     name: cnpg-secret

--- a/kubernetes/apps/database/cnpg/cluster/kustomization.yaml
+++ b/kubernetes/apps/database/cnpg/cluster/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cluster16.yaml
+  # - ./prometheusrule.yaml
+  - ./scheduledbackup.yaml
+  - ./service.yaml

--- a/kubernetes/apps/database/cnpg/cluster/prometheusrule.yaml
+++ b/kubernetes/apps/database/cnpg/cluster/prometheusrule.yaml
@@ -1,0 +1,76 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cnpg-rules
+  labels:
+    prometheus: k8s
+    role: alert-rules
+spec:
+  groups:
+    - name: cnpg.rules
+      rules:
+        - alert: LongRunningTransaction
+          annotations:
+            description: Pod {{ $labels.pod }} is taking more than 5 minutes (300 seconds) for a query.
+            summary: A query is taking longer than 5 minutes.
+          expr: |-
+            cnpg_backends_max_tx_duration_seconds > 300
+          for: 1m
+          labels:
+            severity: warning
+        - alert: BackendsWaiting
+          annotations:
+            description: Pod {{ $labels.pod }} has been waiting for longer than 5 minutes
+            summary: If a backend is waiting for longer than 5 minutes
+          expr: |-
+            cnpg_backends_waiting_total > 300
+          for: 1m
+          labels:
+            severity: warning
+        - alert: PGDatabase
+          annotations:
+            description: Over 300,000,000 transactions from frozen xid on pod {{ $labels.pod }}
+            summary: Number of transactions from the frozen XID to the current one
+          expr: |-
+            cnpg_pg_database_xid_age > 300000000
+          for: 1m
+          labels:
+            severity: warning
+        - alert: PGReplication
+          annotations:
+            description: Standby is lagging behind by over 300 seconds (5 minutes)
+            summary: The standby is lagging behind the primary
+          expr: |-
+            cnpg_pg_replication_lag > 300
+          for: 1m
+          labels:
+            severity: warning
+        - alert: LastFailedArchiveTime
+          annotations:
+            description: Archiving failed for {{ $labels.pod }}
+            summary: Checks the last time archiving failed. Will be < 0 when it has not failed.
+          expr: |-
+            (cnpg_pg_stat_archiver_last_failed_time - cnpg_pg_stat_archiver_last_archived_time) > 1
+          for: 1m
+          labels:
+            severity: warning
+        - alert: DatabaseDeadlockConflicts
+          annotations:
+            description: There are over 10 deadlock conflicts in {{ $labels.pod }}
+            summary: Checks the number of database conflicts
+          expr: |-
+            cnpg_pg_stat_database_deadlocks > 10
+          for: 1m
+          labels:
+            severity: warning
+        - alert: ReplicaFailingReplication
+          annotations:
+            description: Replica {{ $labels.pod }} is failing to replicate
+            summary: Checks if the replica is failing to replicate
+          expr: |-
+            cnpg_pg_replication_in_recovery > cnpg_pg_replication_is_wal_receiver_up
+          for: 1m
+          labels:
+            severity: warning

--- a/kubernetes/apps/database/cnpg/cluster/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cnpg/cluster/scheduledbackup.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: postgres16
+spec:
+  schedule: "@daily"
+  immediate: true
+  backupOwnerReference: self
+  cluster:
+    name: postgres16

--- a/kubernetes/apps/database/cnpg/cluster/service.yaml
+++ b/kubernetes/apps/database/cnpg/cluster/service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres16
+  annotations:
+    lbipam.cilium.io/ips: 10.0.20.17
+    external-dns.alpha.kubernetes.io/hostname: "postgres.${SECRET_DOMAIN}"
+spec:
+  type: LoadBalancer
+  selector:
+    cnpg.io/cluster: postgres16
+    cnpg.io/instanceRole: primary
+  ports:
+    - name: postgres
+      port: 5432
+      protocol: TCP
+      targetPort: 5432

--- a/kubernetes/apps/database/cnpg/ks.yaml
+++ b/kubernetes/apps/database/cnpg/ks.yaml
@@ -1,0 +1,52 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cnpg-operator
+  namespace: &namespace database
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: akeyless-secret-store
+      namespace: external-secrets
+  interval: 30m
+  path: ./kubernetes/apps/database/cnpg/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cnpg-cluster
+  namespace: &namespace database
+spec:
+  dependsOn:
+    - name: cnpg
+      namespace: *namespace
+    - name: openebs
+      namespace: openebs-system
+  interval: 30m
+  path: ./kubernetes/apps/database/cnpg/cluster
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/database/cnpg/ks.yaml
+++ b/kubernetes/apps/database/cnpg/ks.yaml
@@ -10,7 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: akeyless-secret-store
+    - name: external-secrets
       namespace: external-secrets
   interval: 30m
   path: ./kubernetes/apps/database/cnpg/app
@@ -31,7 +31,7 @@ metadata:
   namespace: &namespace database
 spec:
   dependsOn:
-    - name: cnpg
+    - name: cnpg-operator
       namespace: *namespace
     - name: openebs
       namespace: openebs-system

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../components/common
+namespace: database
+resources:
+  - ./cnpg/ks.yaml
+  # - ./dragonfly/ks.yaml

--- a/kubernetes/components/cnpg/README.md
+++ b/kubernetes/components/cnpg/README.md
@@ -1,0 +1,14 @@
+## CloudNative PG
+
+### Populate Secrets for new App
+
+```
+export APP=mealie
+PASSWORD=$(openssl rand -base64 15)
+akeyless update-secret-val \
+  --name cnpg-users \
+  --custom-field "${APP}_postgres_username=${APP}" \
+  --custom-field "${APP}_postgres_password=${PASSWORD}"
+```
+
+`${CNPG_NAME:=postgres16}` comes from each app's ks.yaml postBuild > substitute schema

--- a/kubernetes/components/cnpg/cronjob.yaml
+++ b/kubernetes/components/cnpg/cronjob.yaml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://github.com/instrumenta/kubernetes-json-schema/raw/refs/heads/master/v1.18.1/cronjob.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: &name ${APP}-pg-backups
+spec:
+  schedule: 5 */4 * * *
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 30
+      template:
+        spec:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            runAsNonRoot: true
+            fsGroupChangePolicy: OnRootMismatch
+            supplementalGroups:
+              - 65539
+          containers:
+            - name: *name
+              # https://github.com/prodrigestivill/docker-postgres-backup-local/discussions/109
+              image: docker.io/prodrigestivill/postgres-backup-local:16
+              imagePullPolicy: IfNotPresent
+              command:
+                - /backup.sh
+              env:
+                - name: POSTGRES_HOST
+                  value: ${CNPG_NAME:=postgres16}-rw.database.svc.cluster.local
+                - name: POSTGRES_DB
+                  value: ${APP}
+                - name: POSTGRES_USER
+                  valueFrom:
+                    secretKeyRef:
+                      key: user
+                      name: ${APP}-pguser-secret
+                - name: POSTGRES_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: ${APP}-pguser-secret
+              volumeMounts:
+                - mountPath: /backups
+                  name: backups
+          restartPolicy: OnFailure
+          volumes:
+            - name: backups
+              nfs:
+                path: /mnt/user/backup/kubernetes/postgres
+                server: "192.168.1.190"

--- a/kubernetes/components/cnpg/externalsecret.yaml
+++ b/kubernetes/components/cnpg/externalsecret.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: &name "${APP}-initdb-secret"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless-secret-store
+  target:
+    name: *name
+    template:
+      data:
+        INIT_POSTGRES_DBNAME: ${APP}
+        INIT_POSTGRES_HOST: ${CNPG_NAME:=postgres16}-rw.database.svc.cluster.local
+        INIT_POSTGRES_USER: "{{ .${APP}_postgres_username }}"
+        INIT_POSTGRES_PASS: "{{ .${APP}_postgres_password }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: /cnpg-users
+    - extract:
+        key: /cnpg-operator
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: &name "${APP}-pguser-secret"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless-secret-store
+  target:
+    name: *name
+    template:
+      data:
+        port: "5432"
+        host: ${CNPG_NAME:=postgres16}-rw.database.svc.cluster.local
+        ro_host: ${CNPG_NAME:=postgres16}-ro.database.svc.cluster.local
+        user: "{{ .${APP}_postgres_username }}"
+        password: "{{ .${APP}_postgres_password }}"
+        db: "${APP}"
+        uri: postgresql://${APP}:{{ .${APP}_postgres_password }}@${CNPG_NAME:=postgres16}-rw.database.svc.cluster.local:5432/${APP}
+        dsn: "host=${CNPG_NAME:=postgres16}-rw.database.svc.cluster.local port=5432 user={{ .${APP}_postgres_username }} password={{ .${APP}_postgres_password }} dbname=${APP} sslmode=disable"
+  dataFrom:
+    - extract:
+        key: /cnpg-users

--- a/kubernetes/components/cnpg/kustomization.yaml
+++ b/kubernetes/components/cnpg/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./cronjob.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/flux/meta/repos/cloudnative-pg.yaml
+++ b/kubernetes/flux/meta/repos/cloudnative-pg.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: cloudnative-pg
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://cloudnative-pg.github.io/charts

--- a/kubernetes/flux/meta/repos/kustomization.yaml
+++ b/kubernetes/flux/meta/repos/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cloudnative-pg.yaml
   - ./external-dns.yaml
   - ./ingress-nginx.yaml


### PR DESCRIPTION
Adds CNPG based on [mchestr/home-cluster](https://github.com/mchestr/home-cluster/tree/b574a5a511c71c753197527f848e16f9f5382d19/kubernetes/apps/database/cloudnative-pg), which implements a single cluster with 3 replicas, and each app will init its own PostgreSQL DB in that single cluster. 

TODO: 
- [ ] You need to migrate your current setup, where each app has its own cluster.

NOTES:
- Pros -> This saves on the number of pods running and S3 backup calls
- Cons -> This is a single point of failure even though it's replicated. If the cluster is down, all apps are affected