### PR TITLE
feat: add dragonfly redis

### DIFF
--- a/kubernetes/apps/database/dragonfly/app/helm/kustomizeconfig.yaml
+++ b/kubernetes/apps/database/dragonfly/app/helm/kustomizeconfig.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/kubernetes/apps/database/dragonfly/app/helm/values.yaml
+++ b/kubernetes/apps/database/dragonfly/app/helm/values.yaml
@@ -1,0 +1,23 @@
+---
+grafanaDashboard:
+  enabled: true
+serviceMonitor:
+  enabled: true
+prometheusRule:
+  enabled: true
+  spec:
+    - alert: DragonflyMissing
+      expr: absent(dragonfly_uptime_in_seconds) == 1
+      for: 0m
+      labels:
+        severity: critical
+      annotations:
+        summary: Dragonfly is missing
+        description: "Dragonfly is missing"
+podSecurityContext:
+  fsGroup: 2000
+securityContext:
+  capabilities: { drop: ["ALL"] }
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000

--- a/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
+++ b/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1beta2.json
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: dragonfly-operator
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v1.1.11
+  url: oci://ghcr.io/dragonflydb/dragonfly-operator/helm/dragonfly-operator
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dragonfly-operator
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: dragonfly-operator
+  install:
+    disableHooks: true
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    disableHooks: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: dragonfly-values

--- a/kubernetes/apps/database/dragonfly/app/kustomization.yaml
+++ b/kubernetes/apps/database/dragonfly/app/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # renovate: datasource=github-releases depName=dragonflydb/dragonfly-operator
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: dragonfly-values
+    files:
+      - values.yaml=./helm/values.yaml
+configurations:
+  - ./helm/kustomizeconfig.yaml

--- a/kubernetes/apps/database/dragonfly/cluster/cluster.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/cluster.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/dragonflydb.io/dragonfly_v1alpha1.json
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: &app dragonfly-cluster
+spec:
+  args:
+    - --maxmemory=$(MAX_MEMORY)Mi
+    - --proactor_threads=2
+    - --cluster_mode=emulated
+    - --default_lua_flags=allow-undeclared-keys
+    - --s3_endpoint=${AWS_REDIS_BUCKET}.s3.us-east-1.amazonaws.com
+  env:
+    - name: MAX_MEMORY
+      valueFrom:
+        resourceFieldRef:
+          resource: limits.memory
+          divisor: 1Mi
+    - name: AWS_ACCESS_KEY_ID
+      valueFrom:
+        secretKeyRef:
+          key: aws-access-key-id
+          name: dragonfly-secret
+    - name: AWS_SECRET_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          key: aws-secret-access-key
+          name: dragonfly-secret
+  image: ghcr.io/dragonflydb/dragonfly:v1.29.0
+  labels:
+    dragonflydb.io/cluster: *app
+  replicas: 3
+  resources:
+    requests:
+      cpu: 100m
+    limits:
+      memory: 512Mi
+  snapshot:
+    dir: "s3://${AWS_REDIS_BUCKET}/"
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: "kubernetes.io/hostname"
+      whenUnsatisfiable: "DoNotSchedule"
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/part-of: *app

--- a/kubernetes/apps/database/dragonfly/cluster/externalsecret.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name dragonfly-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless-secret-store
+  target:
+    name: *name
+    template:
+      data:
+        aws-access-key-id: "{{ .AWS_ACCESS_KEY_ID }}"
+        aws-secret-access-key: "{{ .AWS_SECRET_ACCESS_KEY }}"
+        AWS_REDIS_BUCKET: "{{ .AWS_CNPG_BUCKET }}"
+  dataFrom:
+    - extract:
+        key: /aws-creds

--- a/kubernetes/apps/database/dragonfly/cluster/kustomization.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/kustomization.yaml
@@ -3,7 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./cluster16.yaml
-  # - ./prometheusrule.yaml
-  - ./scheduledbackup.yaml
-  - ./service.yaml
+  - ./cluster.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/database/dragonfly/ks.yaml
+++ b/kubernetes/apps/database/dragonfly/ks.yaml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app dragonfly-operator
+  namespace: &namespace database
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 30m
+  path: ./kubernetes/apps/database/dragonfly/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 15m
+  wait: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app dragonfly-cluster
+  namespace: &namespace database
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: dragonfly-operator
+      namespace: *namespace
+    - name: external-secrets
+      namespace: external-secrets
+  healthCheckExprs:
+    - apiVersion: dragonflydb.io/v1alpha1
+      kind: Dragonfly
+      current: status.phase == 'ready'
+  interval: 30m
+  path: ./kubernetes/apps/database/dragonfly/cluster
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: homelab-ops
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 15m
+  wait: true

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -7,4 +7,4 @@ components:
 namespace: database
 resources:
   - ./cnpg/ks.yaml
-  # - ./dragonfly/ks.yaml
+  - ./dragonfly/ks.yaml


### PR DESCRIPTION
Attempting to follow the same concept as CNPG where there is 1 central redis cluster, and each app will identify a different DB index #  