### PR TITLE
feat: add reverse-proxies

### DIFF
--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -8,4 +8,5 @@ components:
 resources:
   - ./external/ks.yaml
   - ./internal/ks.yaml
+  - ./proxy/externalsecret.yaml
   - ./proxy/ks.yaml

--- a/kubernetes/apps/network/proxy/3dp/ingress.yaml
+++ b/kubernetes/apps/network/proxy/3dp/ingress.yaml
@@ -3,13 +3,11 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: &name proxy-nas
-  annotations:
-    external-dns.alpha.kubernetes.io/hostname: "external.${SECRET_DOMAIN}"
+  name: &name proxy-3dp
 spec:
-  ingressClassName: external
+  ingressClassName: internal
   rules:
-    - host: "nas.${SECRET_DOMAIN}"
+    - host: "3dp.local.${SECRET_DOMAIN}"
       http:
         paths:
           - path: /

--- a/kubernetes/apps/network/proxy/3dp/kustomization.yaml
+++ b/kubernetes/apps/network/proxy/3dp/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ingress.yaml
+  - ./service.yaml

--- a/kubernetes/apps/network/proxy/3dp/service.yaml
+++ b/kubernetes/apps/network/proxy/3dp/service.yaml
@@ -3,13 +3,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: &name proxy-nas
+  name: &name proxy-3dp
   labels:
     app: *name
 spec:
   ports:
     - port: 80
-      targetPort: 4000
+      targetPort: 80
       protocol: TCP
   selector: {} # No pods
 ---
@@ -17,10 +17,10 @@ spec:
 apiVersion: v1
 kind: Endpoints
 metadata:
-  name: proxy-nas
+  name: proxy-3dp
 subsets:
   - addresses:
-      - ip: "${SYNO_IP}"
+      - ip: "${3DP_IP}"
     ports:
-      - port: 4000
+      - port: 80
         protocol: TCP

--- a/kubernetes/apps/network/proxy/adguard/ingress.yaml
+++ b/kubernetes/apps/network/proxy/adguard/ingress.yaml
@@ -3,13 +3,11 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: &name proxy-nas
-  annotations:
-    external-dns.alpha.kubernetes.io/hostname: "external.${SECRET_DOMAIN}"
+  name: &name proxy-adguard
 spec:
-  ingressClassName: external
+  ingressClassName: internal
   rules:
-    - host: "nas.${SECRET_DOMAIN}"
+    - host: "ag.local.${SECRET_DOMAIN}"
       http:
         paths:
           - path: /

--- a/kubernetes/apps/network/proxy/adguard/kustomization.yaml
+++ b/kubernetes/apps/network/proxy/adguard/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ingress.yaml
+  - ./service.yaml

--- a/kubernetes/apps/network/proxy/adguard/service.yaml
+++ b/kubernetes/apps/network/proxy/adguard/service.yaml
@@ -3,13 +3,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: &name proxy-nas
+  name: &name proxy-adguard
   labels:
     app: *name
 spec:
   ports:
     - port: 80
-      targetPort: 4000
+      targetPort: 80
       protocol: TCP
   selector: {} # No pods
 ---
@@ -17,10 +17,10 @@ spec:
 apiVersion: v1
 kind: Endpoints
 metadata:
-  name: proxy-nas
+  name: proxy-adguard
 subsets:
   - addresses:
-      - ip: "${SYNO_IP}"
+      - ip: "${ADGUARD_IP}"
     ports:
-      - port: 4000
+      - port: 80
         protocol: TCP

--- a/kubernetes/apps/network/proxy/dad/ingress.yaml
+++ b/kubernetes/apps/network/proxy/dad/ingress.yaml
@@ -3,13 +3,13 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: &name proxy-nas
+  name: &name proxy-dadnas
   annotations:
     external-dns.alpha.kubernetes.io/hostname: "external.${SECRET_DOMAIN}"
 spec:
   ingressClassName: external
   rules:
-    - host: "nas.${SECRET_DOMAIN}"
+    - host: "dad.${SECRET_DOMAIN}"
       http:
         paths:
           - path: /

--- a/kubernetes/apps/network/proxy/dad/kustomization.yaml
+++ b/kubernetes/apps/network/proxy/dad/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ingress.yaml
+  - ./service.yaml

--- a/kubernetes/apps/network/proxy/dad/service.yaml
+++ b/kubernetes/apps/network/proxy/dad/service.yaml
@@ -3,13 +3,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: &name proxy-nas
+  name: &name proxy-dadnas
   labels:
     app: *name
 spec:
   ports:
     - port: 80
-      targetPort: 4000
+      targetPort: 5000
       protocol: TCP
   selector: {} # No pods
 ---
@@ -17,10 +17,10 @@ spec:
 apiVersion: v1
 kind: Endpoints
 metadata:
-  name: proxy-nas
+  name: proxy-dadnas
 subsets:
   - addresses:
-      - ip: "${SYNO_IP}"
+      - ip: "${DADNAS_IP}"
     ports:
-      - port: 4000
+      - port: 5000
         protocol: TCP

--- a/kubernetes/apps/network/proxy/externalsecret.yaml
+++ b/kubernetes/apps/network/proxy/externalsecret.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name proxy-secrets
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless-secret-store
+  target:
+    name: *name
+    template:
+      data:
+        ADGUARD_IP: "{{ .ADGUARD_IP }}"
+        DADNAS_IP: "{{ .DADNAS_IP }}"
+        GREY_IP: "{{ .GREY_IP }}"
+        HASSIO_IP: "{{ .HASSIO_IP }}"
+        PLEX_IP: "{{ .PLEX_IP }}"
+        SYNO_IP: "{{ .NAS_IP }}"
+        3DP_IP: "{{ .3DP_IP }}"
+  dataFrom:
+    - extract:
+        key: /nginx-proxy

--- a/kubernetes/apps/network/proxy/grey/ingress.yaml
+++ b/kubernetes/apps/network/proxy/grey/ingress.yaml
@@ -3,13 +3,13 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: &name proxy-nas
+  name: &name proxy-grey
   annotations:
     external-dns.alpha.kubernetes.io/hostname: "external.${SECRET_DOMAIN}"
 spec:
   ingressClassName: external
   rules:
-    - host: "nas.${SECRET_DOMAIN}"
+    - host: "grey.${SECRET_DOMAIN}"
       http:
         paths:
           - path: /

--- a/kubernetes/apps/network/proxy/grey/kustomization.yaml
+++ b/kubernetes/apps/network/proxy/grey/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ingress.yaml
+  - ./service.yaml

--- a/kubernetes/apps/network/proxy/grey/service.yaml
+++ b/kubernetes/apps/network/proxy/grey/service.yaml
@@ -3,13 +3,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: &name proxy-nas
+  name: &name proxy-grey
   labels:
     app: *name
 spec:
   ports:
     - port: 80
-      targetPort: 4000
+      targetPort: 5000
       protocol: TCP
   selector: {} # No pods
 ---
@@ -17,10 +17,10 @@ spec:
 apiVersion: v1
 kind: Endpoints
 metadata:
-  name: proxy-nas
+  name: proxy-grey
 subsets:
   - addresses:
-      - ip: "${SYNO_IP}"
+      - ip: "${GREY_IP}"
     ports:
-      - port: 4000
+      - port: 5000
         protocol: TCP

--- a/kubernetes/apps/network/proxy/hassio/ingress.yaml
+++ b/kubernetes/apps/network/proxy/hassio/ingress.yaml
@@ -3,13 +3,13 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: &name proxy-nas
+  name: &name proxy-hassio
   annotations:
     external-dns.alpha.kubernetes.io/hostname: "external.${SECRET_DOMAIN}"
 spec:
   ingressClassName: external
   rules:
-    - host: "nas.${SECRET_DOMAIN}"
+    - host: "ha.${SECRET_DOMAIN}"
       http:
         paths:
           - path: /

--- a/kubernetes/apps/network/proxy/hassio/kustomization.yaml
+++ b/kubernetes/apps/network/proxy/hassio/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ingress.yaml
+  - ./service.yaml

--- a/kubernetes/apps/network/proxy/hassio/service.yaml
+++ b/kubernetes/apps/network/proxy/hassio/service.yaml
@@ -3,13 +3,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: &name proxy-nas
+  name: &name proxy-hassio
   labels:
     app: *name
 spec:
   ports:
     - port: 80
-      targetPort: 4000
+      targetPort: 8123
       protocol: TCP
   selector: {} # No pods
 ---
@@ -17,10 +17,10 @@ spec:
 apiVersion: v1
 kind: Endpoints
 metadata:
-  name: proxy-nas
+  name: proxy-hassio
 subsets:
   - addresses:
-      - ip: "${SYNO_IP}"
+      - ip: "${HASSIO_IP}"
     ports:
-      - port: 4000
+      - port: 8123
         protocol: TCP

--- a/kubernetes/apps/network/proxy/ks.yaml
+++ b/kubernetes/apps/network/proxy/ks.yaml
@@ -13,11 +13,15 @@ spec:
   dependsOn:
     - name: cert-manager-tls
       namespace: cert-manager
+    - name: external-secrets
+      namespace: external-secrets
   path: ./kubernetes/apps/network/proxy
   postBuild:
     substituteFrom:
       - kind: Secret
         name: cluster-secrets
+      - kind: Secret
+        name: proxy-secrets
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/network/proxy/plex/ingress.yaml
+++ b/kubernetes/apps/network/proxy/plex/ingress.yaml
@@ -3,13 +3,13 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: &name proxy-nas
+  name: &name proxy-plex
   annotations:
     external-dns.alpha.kubernetes.io/hostname: "external.${SECRET_DOMAIN}"
 spec:
   ingressClassName: external
   rules:
-    - host: "nas.${SECRET_DOMAIN}"
+    - host: "plex.${SECRET_DOMAIN}"
       http:
         paths:
           - path: /

--- a/kubernetes/apps/network/proxy/plex/kustomization.yaml
+++ b/kubernetes/apps/network/proxy/plex/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ingress.yaml
+  - ./service.yaml

--- a/kubernetes/apps/network/proxy/plex/service.yaml
+++ b/kubernetes/apps/network/proxy/plex/service.yaml
@@ -3,13 +3,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: &name proxy-nas
+  name: &name proxy-plex
   labels:
     app: *name
 spec:
   ports:
     - port: 80
-      targetPort: 4000
+      targetPort: 32400
       protocol: TCP
   selector: {} # No pods
 ---
@@ -17,10 +17,10 @@ spec:
 apiVersion: v1
 kind: Endpoints
 metadata:
-  name: proxy-nas
+  name: proxy-plex
 subsets:
   - addresses:
-      - ip: "${SYNO_IP}"
+      - ip: "${PLEX_IP}"
     ports:
-      - port: 4000
+      - port: 32400
         protocol: TCP


### PR DESCRIPTION
Adds 8 reverse proxies needed for the switch from k3s by techno tim for external resources not yet included in k8s by onedr0p. 