### PR TITLE
Default/immich1

### DIFF
--- a/kubernetes/apps/database/cnpg/cluster/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cnpg/cluster/scheduledbackup.yaml
@@ -10,15 +10,15 @@ spec:
   backupOwnerReference: self
   cluster:
     name: postgres16
-# ---
-# # yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/postgresql.cnpg.io/scheduledbackup_v1.json
-# apiVersion: postgresql.cnpg.io/v1
-# kind: ScheduledBackup
-# metadata:
-#   name: immich
-# spec:
-#   schedule: "0 30 3 * * *"
-#   immediate: true
-#   backupOwnerReference: self
-#   cluster:
-#     name: immich
+---
+# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: immich
+spec:
+  schedule: "0 30 3 * * *"
+  immediate: true
+  backupOwnerReference: self
+  cluster:
+    name: immich

--- a/kubernetes/apps/default/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/default/immich/app/helmrelease.yaml
@@ -92,7 +92,7 @@ spec:
         strategy: RollingUpdate
         containers:
           immich-ml:
-            dependsOn: server
+            dependsOn: app
             image:
               repository: ghcr.io/immich-app/immich-machine-learning
               tag: *tag

--- a/kubernetes/apps/default/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/default/immich/app/helmrelease.yaml
@@ -92,7 +92,6 @@ spec:
         strategy: RollingUpdate
         containers:
           immich-ml:
-            dependsOn: app
             image:
               repository: ghcr.io/immich-app/immich-machine-learning
               tag: *tag

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
   - ./actual/ks.yaml
   - ./authentik/ks.yaml
   - ./echo/ks.yaml
-  # - ./immich/ks.yaml
+  - ./immich/ks.yaml
   - ./mealie/ks.yaml
   - ./minio/ks.yaml
   - ./ntfy/ks.yaml


### PR DESCRIPTION
added config to immich pgsql to hopefully help bootstrap it
```yaml
  bootstrap:
    initdb:
      postInitSQL:
        - CREATE EXTENSION IF NOT EXISTS "vectors";
        - ALTER DATABASE immich SET search_path = "$user", public, vectors;
        - GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA vectors TO immich;
        - GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO immich;
```
added scheduled (local nfs) backups for cnpg
renamed immich to server so the pod runs as immich-server