### PR TITLE
chore: normalize helm install, upgrade, uninstall, maxHistory

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/app/helmrelease.yaml
@@ -19,10 +19,11 @@ kind: HelmRelease
 metadata:
   name: &name actions-runner-controller
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: gha-runner-scale-set-controller
+  maxHistory: 2
+  interval: 1h
   install:
     crds: CreateReplace
     remediation:
@@ -31,7 +32,10 @@ spec:
     cleanupOnFail: true
     crds: CreateReplace
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     fullnameOverride: *name
     replicaCount: 1

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/helmrelease.yaml
@@ -19,17 +19,21 @@ kind: HelmRelease
 metadata:
   name: &name home-ops-runner
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: gha-runner-scale-set
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     githubConfigUrl: https://github.com/tscibilia/home-ops
     githubConfigSecret: home-ops-runner-secret

--- a/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml
@@ -17,19 +17,23 @@ spec:
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: cert-manager
+  name: &app cert-manager
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
-    name: cert-manager
+    name: *app
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   valuesFrom:
     - kind: ConfigMap
       name: cert-manager-values

--- a/kubernetes/apps/default/actual/app/helmrelease.yaml
+++ b/kubernetes/apps/default/actual/app/helmrelease.yaml
@@ -5,10 +5,11 @@ kind: HelmRelease
 metadata:
   name: &app actual
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
@@ -17,9 +18,11 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      actual:
+      *app :
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/default/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/default/authentik/app/helmrelease.yaml
@@ -19,17 +19,21 @@ kind: HelmRelease
 metadata:
   name: &app authentik
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: authentik
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     global:
       fullnameOverride: *app

--- a/kubernetes/apps/default/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/default/echo/app/helmrelease.yaml
@@ -3,25 +3,29 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: echo
+  name: &app echo
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   dependsOn:
     - name: cloudflared
       namespace: network
   values:
     controllers:
-      echo:
+      *app :
         strategy: RollingUpdate
         containers:
           app:
@@ -63,13 +67,13 @@ spec:
         seccompProfile: { type: RuntimeDefault }
     service:
       app:
-        controller: echo
+        controller: *app
         ports:
           http:
             port: *port
     serviceMonitor:
       app:
-        serviceName: echo
+        serviceName: *app
         endpoints:
           - port: http
             scheme: http

--- a/kubernetes/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/app/helmrelease.yaml
@@ -5,10 +5,11 @@ kind: HelmRelease
 metadata:
   name: &app homepage
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
@@ -17,9 +18,11 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      homepage:
+      *app :
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/default/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/default/immich/app/helmrelease.yaml
@@ -5,17 +5,18 @@ kind: HelmRelease
 metadata:
   name: &app immich
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
   maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
   uninstall:
     keepHistory: false

--- a/kubernetes/apps/default/komga/app/helmrelease.yaml
+++ b/kubernetes/apps/default/komga/app/helmrelease.yaml
@@ -5,17 +5,18 @@ kind: HelmRelease
 metadata:
   name: &app komga
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
   maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
   uninstall:
     keepHistory: false
@@ -50,14 +51,12 @@ spec:
         fsGroup: 100
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile: { type: RuntimeDefault }
-
     service:
       app:
         controller: *app
         ports:
           http:
             port: *port
-
     ingress:
       app:
         className: external
@@ -70,7 +69,6 @@ spec:
                 service:
                   identifier: app
                   port: http
-
     persistence:
       media:
         type: persistentVolumeClaim

--- a/kubernetes/apps/default/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mealie/app/helmrelease.yaml
@@ -5,10 +5,11 @@ kind: HelmRelease
 metadata:
   name: &app mealie
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
@@ -17,9 +18,11 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      mealie:
+      *app :
         annotations:
           reloader.stakater.com/auto: "true"
         initContainers:

--- a/kubernetes/apps/default/minio/app/helmrelease.yaml
+++ b/kubernetes/apps/default/minio/app/helmrelease.yaml
@@ -5,10 +5,11 @@ kind: HelmRelease
 metadata:
   name: &app minio
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
@@ -17,9 +18,11 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      minio:
+      *app :
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/default/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/default/open-webui/app/helmrelease.yaml
@@ -5,10 +5,11 @@ kind: HelmRelease
 metadata:
   name: &app open-webui
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
@@ -17,9 +18,11 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      open-webui:
+      *app :
         strategy: Recreate
         annotations:
           reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/default/pairdrop/app/helmrelease.yaml
+++ b/kubernetes/apps/default/pairdrop/app/helmrelease.yaml
@@ -5,10 +5,11 @@ kind: HelmRelease
 metadata:
   name: &app pairdrop
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
@@ -17,9 +18,11 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      pairdrop:
+      *app :
         strategy: RollingUpdate
         annotations:
           reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/default/radicale/app/helmrelease.yaml
+++ b/kubernetes/apps/default/radicale/app/helmrelease.yaml
@@ -5,11 +5,11 @@ kind: HelmRelease
 metadata:
   name: &app radicale
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
   maxHistory: 2
+  interval: 30m
   install:
     remediation:
       retries: -1
@@ -22,7 +22,7 @@ spec:
     keepHistory: false
   values:
     controllers:
-      radicale:
+      *app :
         strategy: Recreate
         annotations:
           reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/default/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/default/searxng/app/helmrelease.yaml
@@ -5,10 +5,11 @@ kind: HelmRelease
 metadata:
   name: &app searxng
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
@@ -17,6 +18,8 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
       *app :

--- a/kubernetes/apps/default/spoolman/app/helmrelease.yaml
+++ b/kubernetes/apps/default/spoolman/app/helmrelease.yaml
@@ -5,10 +5,11 @@ kind: HelmRelease
 metadata:
   name: &app spoolman
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
@@ -17,9 +18,11 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      spoolman:
+      *app :
         strategy: Recreate
         annotations:
           reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/default/vaultwarden/app/helmrelease.yaml
+++ b/kubernetes/apps/default/vaultwarden/app/helmrelease.yaml
@@ -5,10 +5,11 @@ kind: HelmRelease
 metadata:
   name: &app vaultwarden
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
@@ -17,9 +18,11 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      vaultwarden:
+      *app :
         strategy: Recreate
         annotations:
           reloader.stakater.com/auto: "true"
@@ -75,7 +78,7 @@ spec:
         annotations:
           external-dns.alpha.kubernetes.io/target: "external.${SECRET_DOMAIN}"
         hosts:
-          - host: "pw.${SECRET_DOMAIN}"
+          - host: "${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}"
             paths:
               - path: /
                 service:

--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -5,20 +5,24 @@ kind: HelmRelease
 metadata:
   name: &app bazarr
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      bazarr:
+      *app :
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/media/flaresolverr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/flaresolverr/app/helmrelease.yaml
@@ -5,20 +5,24 @@ kind: HelmRelease
 metadata:
   name: &app flaresolverr
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      flaresolverr:
+      *app :
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -5,17 +5,21 @@ kind: HelmRelease
 metadata:
   name: &app jellyfin
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
       *app :

--- a/kubernetes/apps/media/jellyseerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyseerr/app/helmrelease.yaml
@@ -5,20 +5,24 @@ kind: HelmRelease
 metadata:
   name: &app jellyseerr
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      jellyseerr:
+      *app :
         annotations:
           reloader.stakater.com/auto: 'true'
         containers:

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -5,20 +5,24 @@ kind: HelmRelease
 metadata:
   name: &app prowlarr
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      prowlarr:
+      *app :
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -6,19 +6,23 @@ kind: HelmRelease
 metadata:
   name: &app qbittorrent
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
   driftDetection:
     mode: enabled
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
       *app :

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -5,10 +5,11 @@ kind: HelmRelease
 metadata:
   name: &app radarr
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
@@ -17,9 +18,11 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      radarr:
+      *app :
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -5,10 +5,11 @@ kind: HelmRelease
 metadata:
   name: &app sabnzbd
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
@@ -17,9 +18,11 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      sabnzbd:
+      *app :
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -5,10 +5,11 @@ kind: HelmRelease
 metadata:
   name: &app sonarr
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
@@ -17,9 +18,11 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      sonarr:
+      *app :
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -5,20 +5,24 @@ kind: HelmRelease
 metadata:
   name: &app tautulli
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      tautulli:
+      *app :
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/network/external/cloudflared/helmrelease.yaml
+++ b/kubernetes/apps/network/external/cloudflared/helmrelease.yaml
@@ -3,22 +3,26 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: cloudflared
+  name: &app cloudflared
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: 3
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      cloudflared:
+      *app :
         strategy: RollingUpdate
         annotations:
           reloader.stakater.com/auto: "true"
@@ -67,13 +71,13 @@ spec:
         seccompProfile: { type: RuntimeDefault }
     service:
       app:
-        controller: cloudflared
+        controller: *app
         ports:
           http:
             port: *port
     serviceMonitor:
       app:
-        serviceName: cloudflared
+        serviceName: *app
         endpoints:
           - port: http
             scheme: http

--- a/kubernetes/apps/network/external/external-dns/helmrelease.yaml
+++ b/kubernetes/apps/network/external/external-dns/helmrelease.yaml
@@ -5,7 +5,6 @@ kind: HelmRelease
 metadata:
   name: &app external-dns
 spec:
-  interval: 1h
   chart:
     spec:
       chart: external-dns
@@ -14,6 +13,8 @@ spec:
         kind: HelmRepository
         name: external-dns
         namespace: flux-system
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: 3
@@ -22,6 +23,8 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     fullnameOverride: *app
     provider: cloudflare
@@ -29,7 +32,7 @@ spec:
       - name: CF_API_TOKEN
         valueFrom:
           secretKeyRef:
-            name: external-dns-secret
+            name: &secret external-dns-secret
             key: api-token
     extraArgs:
       - --cloudflare-dns-records-per-page=1000
@@ -48,4 +51,4 @@ spec:
     serviceMonitor:
       enabled: true
     podAnnotations:
-      secret.reloader.stakater.com/reload: external-dns-secret
+      secret.reloader.stakater.com/reload: *secret

--- a/kubernetes/apps/network/external/ingress-nginx/helmrelease.yaml
+++ b/kubernetes/apps/network/external/ingress-nginx/helmrelease.yaml
@@ -3,9 +3,8 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: external-ingress-nginx
+  name: &app external-ingress-nginx
 spec:
-  interval: 1h
   chart:
     spec:
       chart: ingress-nginx
@@ -14,15 +13,20 @@ spec:
         kind: HelmRepository
         name: ingress-nginx
         namespace: flux-system
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: 3
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
-    fullnameOverride: external-ingress-nginx
+    fullnameOverride: *app
     controller:
       service:
         annotations:

--- a/kubernetes/apps/network/internal/ingress-nginx/helmrelease.yaml
+++ b/kubernetes/apps/network/internal/ingress-nginx/helmrelease.yaml
@@ -3,9 +3,8 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: internal-ingress-nginx
+  name: &app internal-ingress-nginx
 spec:
-  interval: 1h
   chart:
     spec:
       chart: ingress-nginx
@@ -14,15 +13,20 @@ spec:
         kind: HelmRepository
         name: ingress-nginx
         namespace: flux-system
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: 3
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
-    fullnameOverride: internal-ingress-nginx
+    fullnameOverride: *app
     controller:
       service:
         annotations:

--- a/kubernetes/apps/network/internal/k8s-gateway/helmrelease.yaml
+++ b/kubernetes/apps/network/internal/k8s-gateway/helmrelease.yaml
@@ -13,26 +13,30 @@ spec:
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: k8s-gateway
+  name: &app k8s-gateway
 spec:
-  interval: 1h
   chart:
     spec:
-      chart: k8s-gateway
+      chart: *app
       version: 2.4.0
       sourceRef:
         kind: HelmRepository
-        name: k8s-gateway
+        name: *app
         namespace: network
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: 3
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
-    fullnameOverride: k8s-gateway
+    fullnameOverride: *app
     domain: "${SECRET_DOMAIN}"
     ttl: 1
     service:

--- a/kubernetes/apps/network/tailscale/app/helmrelease.yaml
+++ b/kubernetes/apps/network/tailscale/app/helmrelease.yaml
@@ -19,11 +19,11 @@ kind: HelmRelease
 metadata:
   name: &app tailscale-operator
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: *app
   maxHistory: 2
+  interval: 1h
   install:
     crds: CreateReplace
     remediation:
@@ -34,6 +34,8 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     oauthSecretVolume:
       secret:

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
@@ -17,21 +17,25 @@ spec:
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: blackbox-exporter
+  name: &app blackbox-exporter
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
-    name: blackbox-exporter
+    name: *app
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
-    fullnameOverride: blackbox-exporter
+    fullnameOverride: *app
     securityContext:
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false

--- a/kubernetes/apps/observability/exporters/jellyseerr-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/jellyseerr-exporter/app/helmrelease.yaml
@@ -5,22 +5,24 @@ kind: HelmRelease
 metadata:
   name: &app jellyseerr-exporter
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
   uninstall:
     keepHistory: false
   values:
     controllers:
-      jellyseerr-exporter:
+      *app :
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/observability/exporters/prowlarr-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/prowlarr-exporter/app/helmrelease.yaml
@@ -5,22 +5,24 @@ kind: HelmRelease
 metadata:
   name: &app prowlarr-exporter
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
   uninstall:
     keepHistory: false
   values:
     controllers:
-      prowlarr-exporter:
+      *app :
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/observability/exporters/qbittorrent-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/qbittorrent-exporter/app/helmrelease.yaml
@@ -5,22 +5,24 @@ kind: HelmRelease
 metadata:
   name: &app qbittorrent-exporter
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
   uninstall:
     keepHistory: false
   values:
     controllers:
-      qbittorrent-exporter:
+      *app :
         containers:
           app:
             image:

--- a/kubernetes/apps/observability/exporters/radarr-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/radarr-exporter/app/helmrelease.yaml
@@ -5,22 +5,24 @@ kind: HelmRelease
 metadata:
   name: &app radarr-exporter
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
   uninstall:
     keepHistory: false
   values:
     controllers:
-      radarr-exporter:
+      *app :
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/observability/exporters/sabnzbd-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/sabnzbd-exporter/app/helmrelease.yaml
@@ -5,22 +5,24 @@ kind: HelmRelease
 metadata:
   name: &app sabnzbd-exporter
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
   uninstall:
     keepHistory: false
   values:
     controllers:
-      sabnzbd-exporter:
+      *app :
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/observability/exporters/sonarr-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/sonarr-exporter/app/helmrelease.yaml
@@ -5,22 +5,24 @@ kind: HelmRelease
 metadata:
   name: &app sonarr-exporter
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
   uninstall:
     keepHistory: false
   values:
     controllers:
-      sonarr-exporter:
+      *app :
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/observability/exporters/tautulli-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/tautulli-exporter/app/helmrelease.yaml
@@ -5,22 +5,24 @@ kind: HelmRelease
 metadata:
   name: &app tautulli-exporter
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
   uninstall:
     keepHistory: false
   values:
     controllers:
-      tautulli-exporter:
+      *app :
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/observability/fluent-bit/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/fluent-bit/app/helmrelease.yaml
@@ -5,20 +5,22 @@ kind: HelmRelease
 metadata:
   name: &app fluent-bit
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
   values:
     controllers:
-      fluent-bit:
+      *app :
         type: daemonset
         serviceAccount:
           name: *app

--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -5,10 +5,11 @@ kind: HelmRelease
 metadata:
   name: &app gatus
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
@@ -19,7 +20,7 @@ spec:
       retries: 3
   values:
     controllers:
-      gatus:
+      *app :
         replicas: 1
         strategy: Recreate
         annotations:

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -17,19 +17,20 @@ spec:
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: grafana
+  name: &app grafana
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
-    name: grafana
+    name: *app
   maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
   uninstall:
     keepHistory: false

--- a/kubernetes/apps/observability/karma/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/karma/app/helmrelease.yaml
@@ -5,17 +5,21 @@ kind: HelmRelease
 metadata:
   name: &app karma
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
       *app :

--- a/kubernetes/apps/observability/keda/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/keda/app/helmrelease.yaml
@@ -17,18 +17,22 @@ spec:
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: keda
+  name: &app keda
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
-    name: keda
+    name: *app
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     enableServiceLinks: false

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -5,23 +5,27 @@ kind: HelmRelease
 metadata:
   name: &app kromgo
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
   dependsOn:
     - name: victoria-metrics
       namespace: observability
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      kromgo:
+      *app :
         replicas: 2
         strategy: RollingUpdate
         annotations:

--- a/kubernetes/apps/observability/silence-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/silence-operator/app/helmrelease.yaml
@@ -17,12 +17,13 @@ spec:
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: silence-operator
+  name: &app silence-operator
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
-    name: silence-operator
+    name: *app
+  maxHistory: 2
+  interval: 1h
   install:
     crds: CreateReplace
     remediation:
@@ -31,7 +32,10 @@ spec:
     crds: CreateReplace
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     alertmanagerAddress: http://vmalertmanager-stack.observability.svc.cluster.local:9093
     image:

--- a/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
@@ -17,23 +17,27 @@ spec:
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: victoria-logs
+  name: &app victoria-logs
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: victoria-logs-single
   driftDetection:
     mode: enabled
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
-    fullnameOverride: victoria-logs
+    fullnameOverride: *app
     retentionPeriod: 1 # months
     server:
       persistentVolume:
@@ -46,6 +50,6 @@ spec:
         enabled: true
         pathType: Prefix
         hosts:
-          - name: "logs.${SECRET_DOMAIN}"
+          - name: "${APP}.${SECRET_DOMAIN}"
             path: /
             port: http

--- a/kubernetes/apps/observability/victoria-metrics/crds/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/crds/helmrelease.yaml
@@ -17,13 +17,13 @@ spec:
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: victoria-metrics-crds
+  name: &app victoria-metrics-crds
 spec:
   chartRef:
     kind: OCIRepository
-    name: victoria-metrics-crds
-  interval: 15m
-  maxHistory: 3
+    name: *app
+  interval: 30m
+  maxHistory: 2
   install:
     crds: Create
     remediation:
@@ -31,11 +31,12 @@ spec:
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
   uninstall:
     keepHistory: false
   values:
-    fullnameOverride: victoria-metrics-crds
+    fullnameOverride: *app
     crds:
       enabled: true
       # plain == false results in CRDs being rendered as templates which allows them to be upgraded

--- a/kubernetes/apps/observability/victoria-metrics/stack/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/stack/helmrelease.yaml
@@ -78,6 +78,8 @@ spec:
       extraArgs:
         maxLabelsPerTimeseries: "50"
         external.url: "https://vm.${SECRET_DOMAIN}"
+        search.maxConcurrentRequests: "4"
+        search.maxQueueDuration: "15s"
       ingress:
         enabled: true
         ingressClassName: internal

--- a/kubernetes/apps/observability/victoria-metrics/stack/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/stack/helmrelease.yaml
@@ -26,14 +26,15 @@ spec:
   dependsOn:
     - name: victoria-metrics-crds
       namespace: observability
-  interval: 15m
-  maxHistory: 3
+  interval: 30m
+  maxHistory: 2
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
   uninstall:
     keepHistory: false

--- a/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
+++ b/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
@@ -17,12 +17,13 @@ spec:
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: openebs
+  name: &app openebs
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
-    name: openebs
+    name: *app
+  maxHistory: 2
+  interval: 1h
   install:
     disableHooks: true
     remediation:
@@ -31,7 +32,10 @@ spec:
     cleanupOnFail: true
     disableHooks: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     localpv-provisioner:
       localpv:

--- a/kubernetes/apps/system-upgrade/system-upgrade-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/system-upgrade-controller/app/helmrelease.yaml
@@ -5,20 +5,24 @@ kind: HelmRelease
 metadata:
   name: &app system-upgrade-controller
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     controllers:
-      system-upgrade-controller:
+      *app :
         strategy: RollingUpdate
         replicas: 2
         containers:
@@ -44,7 +48,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: ["ALL"] }
         serviceAccount:
-          identifier: system-upgrade-controller
+          identifier: *app
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -59,12 +63,12 @@ spec:
             roles: ["os:admin"]
     rbac:
       bindings:
-        system-upgrade-controller:
+        *app :
           type: ClusterRoleBinding
           roleRef:
             kind: ClusterRole
             name: cluster-admin
           subjects:
-            - identifier: system-upgrade-controller
+            - identifier: *app
     serviceAccount:
-      system-upgrade-controller: {}
+      *app : {}

--- a/kubernetes/apps/volsync-system/volsync/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/helmrelease.yaml
@@ -17,19 +17,23 @@ spec:
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: volsync
+  name: &app volsync
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
-    name: volsync
+    name: *app
+  maxHistory: 2
+  interval: 1h
   install:
     remediation:
       retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
+      strategy: rollback
       retries: 3
+  uninstall:
+    keepHistory: false
   values:
     manageCRDs: true
     replicaCount: 2


### PR DESCRIPTION
Quality of life update, I tried to normalize all of the helmreleases such that there is 
- a maxHistory: 2 (limits the number of revisions saved)
- cleanupOnFail: true (allows deletion of resources on failure)
- remediation.strategy: rollback (on failure, Kubernetes will rollback to the prior config)
- uninstall.keepHistory: false (removes resources on uninstall but keeps history)
- updated yaml `&app` anchors in more places
🤞