### PR TITLE
chore(flux): update kustomization defaults

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
@@ -4,16 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app actions-runner-controller
-  namespace: &namespace actions-runner-system
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: *app
-      namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/app
   prune: true
@@ -21,21 +12,16 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
+  wait: true
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app actions-runner-controller-runners
-  namespace: &namespace actions-runner-system
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: actions-runner-controller
-      namespace: *namespace
     - name: openebs
       namespace: openebs-system
   interval: 1h
@@ -45,5 +31,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/actions-runner-system/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/kustomization.yaml
@@ -5,5 +5,7 @@ kind: Kustomization
 namespace: actions-runner-system
 components:
   - ../../components/common
+replacements:
+  - path: ../../components/replacements/ks.yaml
 resources:
   - ./actions-runner-controller/ks.yaml

--- a/kubernetes/apps/cert-manager/cert-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/ks.yaml
@@ -4,16 +4,12 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app cert-manager
-  namespace: &namespace cert-manager
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: *app
-      namespace: *namespace
+      namespace: *app
     - apiVersion: cert-manager.io/v1
       kind: ClusterIssuer
       name: letsencrypt-production
@@ -24,28 +20,18 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/cert-manager/cert-manager/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
-  wait: true
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app cert-manager-tls
-  namespace: &namespace cert-manager
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: cert-manager
       namespace: cert-manager
@@ -56,14 +42,9 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/cert-manager/cert-manager/tls
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: true

--- a/kubernetes/apps/cert-manager/kustomization.yaml
+++ b/kubernetes/apps/cert-manager/kustomization.yaml
@@ -5,5 +5,7 @@ kind: Kustomization
 namespace: cert-manager
 components:
   - ../../components/common
+replacements:
+  - path: ../../components/replacements/ks.yaml
 resources:
   - ./cert-manager/ks.yaml

--- a/kubernetes/apps/database/cnpg/ks.yaml
+++ b/kubernetes/apps/database/cnpg/ks.yaml
@@ -4,70 +4,55 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app cnpg-operator
-  namespace: &namespace database
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: external-secrets
       namespace: external-secrets
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/database/cnpg/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: true
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: cnpg-cluster
-  namespace: &namespace database
+  name: &app cnpg-cluster
 spec:
   dependsOn:
     - name: cnpg-operator
-      namespace: *namespace
     - name: openebs
       namespace: openebs-system
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/database/cnpg/cluster
   postBuild:
     substituteFrom:
       - kind: Secret
-        name: cluster-secrets
-      - kind: Secret
         name: cnpg-secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: true
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: cnpg-barman-cloud
-  namespace: &namespace database
+  name: &app cnpg-barman-cloud
 spec:
   dependsOn:
     - name: cnpg-operator
-      namespace: *namespace
     - name: cnpg-cluster
-      namespace: *namespace
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/database/cnpg/barman-cloud
   postBuild:
     substituteFrom:
-      - kind: Secret
-        name: cluster-secrets
       - kind: Secret
         name: cnpg-secret
   prune: true
@@ -75,5 +60,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: true

--- a/kubernetes/apps/database/dragonfly/ks.yaml
+++ b/kubernetes/apps/database/dragonfly/ks.yaml
@@ -4,19 +4,14 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app dragonfly-operator
-  namespace: &namespace database
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/database/dragonfly/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: true
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
@@ -24,21 +19,16 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app dragonfly-cluster
-  namespace: &namespace database
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: dragonfly-operator
-      namespace: *namespace
     - name: external-secrets
       namespace: external-secrets
   healthCheckExprs:
     - apiVersion: dragonflydb.io/v1alpha1
       kind: Dragonfly
       current: status.phase == 'Ready'
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/database/dragonfly/cluster
   postBuild:
     substituteFrom:
@@ -49,5 +39,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: true

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 namespace: database
 components:
   - ../../components/common
+replacements:
+  - path: ../../components/replacements/ks.yaml
 resources:
   - ./cnpg/ks.yaml
   - ./dragonfly/ks.yaml

--- a/kubernetes/apps/database/pgadmin/ks.yaml
+++ b/kubernetes/apps/database/pgadmin/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app pgadmin
-  namespace: &namespace database
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/guarded
     - ../../../../components/volsync
@@ -18,21 +14,16 @@ spec:
     - name: volsync
       namespace: volsync-system
     - name: cnpg-cluster
-      namespace: database
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/database/pgadmin/app
   postBuild:
     substitute:
       APP: *app
       GATUS_PATH: /misc/ping
       VOLSYNC_CAPACITY: 1Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/default/actual/ks.yaml
+++ b/kubernetes/apps/default/actual/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app actual
-  namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/guarded
     - ../../../../components/volsync
@@ -19,7 +15,7 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/default/actual/app
   postBuild:
     substitute:
@@ -27,15 +23,11 @@ spec:
       GATUS_PATH: /
       GATUS_SUBDOMAIN: budget
       VOLSYNC_CAPACITY: 3Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -43,14 +35,9 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app actual-tools
-  namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: actual
-      namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/default/actual/tools
   prune: true
@@ -58,5 +45,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/default/authentik/ks.yaml
+++ b/kubernetes/apps/default/authentik/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app authentik
-  namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/external
     - ../../../../components/cnpg
@@ -26,9 +22,6 @@ spec:
       APP: *app
       GATUS_SUBDOMAIN: auth
       CNPG_NAME: &postgresAppName postgres16
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   healthChecks:
     - apiVersion: &postgresVersion postgresql.cnpg.io/v1
       kind: &postgresKind Cluster
@@ -44,5 +37,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/default/echo/ks.yaml
+++ b/kubernetes/apps/default/echo/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app echo
-  namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/external
   interval: 1h
@@ -16,13 +12,9 @@ spec:
   postBuild:
     substitute:
       APP: *app
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/default/guacamole/ks.yaml
+++ b/kubernetes/apps/default/guacamole/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app guacamole
-  namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/guarded
     - ../../../../components/volsync
@@ -26,13 +22,9 @@ spec:
       APP: *app
       GATUS_SUBDOMAIN: rdp
       VOLSYNC_CAPACITY: 2Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/default/homepage/ks.yaml
+++ b/kubernetes/apps/default/homepage/ks.yaml
@@ -4,30 +4,22 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app homepage
-  namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/guarded
   dependsOn:
     - name: external-secrets
       namespace: external-secrets
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/default/homepage/app
   postBuild:
     substitute:
       APP: *app
       GATUS_PATH: /api/healthcheck
       GATUS_SUBDOMAIN: hm
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/default/immich/ks.yaml
+++ b/kubernetes/apps/default/immich/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app immich
-  namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/cnpg
     - ../../../../components/gatus/external
@@ -22,7 +18,7 @@ spec:
       namespace: external-secrets
     - name: keda
       namespace: observability
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/default/immich/app
   postBuild:
     substitute:
@@ -31,9 +27,6 @@ spec:
       GATUS_PATH: /api/server/ping
       CNPG_NAME: &postgresAppName immich17
       PG_VER: "17"
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   healthChecks:
     - apiVersion: &postgresVersion postgresql.cnpg.io/v1
       kind: &postgresKind Cluster
@@ -49,5 +42,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/default/komga/ks.yaml
+++ b/kubernetes/apps/default/komga/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app komga
-  namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/external
     - ../../../../components/keda/nfs-scaler
@@ -27,13 +23,9 @@ spec:
       APP: *app
       GATUS_SUBDOMAIN: rdr
       VOLSYNC_CAPACITY: 3Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 namespace: default
 components:
   - ../../components/common
+replacements:
+  - path: ../../components/replacements/ks.yaml
 resources:
   - ./actual/ks.yaml
   - ./authentik/ks.yaml

--- a/kubernetes/apps/default/mealie/ks.yaml
+++ b/kubernetes/apps/default/mealie/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app mealie
-  namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/external
     - ../../../../components/volsync
@@ -30,9 +26,6 @@ spec:
       GATUS_SUBDOMAIN: mp
       GATUS_PATH: /api/app/about
       CNPG_NAME: &postgresAppName postgres16
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   healthChecks:
     - apiVersion: &postgresVersion postgresql.cnpg.io/v1
       kind: &postgresKind Cluster
@@ -48,5 +41,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/default/minio/ks.yaml
+++ b/kubernetes/apps/default/minio/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app minio
-  namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/external
     - ../../../../components/keda/nfs-scaler
@@ -25,13 +21,9 @@ spec:
       GATUS_PATH: /minio/health/live
       GATUS_SUBDOMAIN: minio
       S3_SUBDOMAIN: s3
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/default/obico/ks.yaml
+++ b/kubernetes/apps/default/obico/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app obico
-  namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/guarded
     - ../../../../components/keda/nfs-scaler
@@ -24,20 +20,16 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/default/obico/app
   postBuild:
     substitute:
       APP: *app
       GATUS_SUBDOMAIN: obico
       VOLSYNC_CAPACITY: 1Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/default/open-webui/ks.yaml
+++ b/kubernetes/apps/default/open-webui/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app open-webui
-  namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/external
     - ../../../../components/volsync
@@ -19,7 +15,7 @@ spec:
       namespace: volsync-system
     - name: rook-ceph-cluster
       namespace: rook-ceph
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/default/open-webui/app
   postBuild:
     substitute:
@@ -27,13 +23,9 @@ spec:
       GATUS_SUBDOMAIN: gpt
       GATUS_PATH: /health
       VOLSYNC_CAPACITY: 2Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/default/pairdrop/ks.yaml
+++ b/kubernetes/apps/default/pairdrop/ks.yaml
@@ -4,26 +4,18 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app pairdrop
-  namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/external
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/default/pairdrop/app
   postBuild:
     substitute:
       APP: *app
       GATUS_SUBDOMAIN: air
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/default/radicale/ks.yaml
+++ b/kubernetes/apps/default/radicale/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app radicale
-  namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/external
     - ../../../../components/volsync
@@ -19,19 +15,15 @@ spec:
       namespace: volsync-system
     - name: rook-ceph-cluster
       namespace: rook-ceph
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/default/radicale/app
   postBuild:
     substitute:
       APP: *app
       GATUS_SUBDOMAIN: dav
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/default/rclone/ks.yaml
+++ b/kubernetes/apps/default/rclone/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app rclone
-  namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/keda/nfs-bkup-scaler
     - ../../../../components/gatus/guarded
@@ -20,13 +16,9 @@ spec:
   postBuild:
     substitute:
       APP: *app
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/default/searxng/ks.yaml
+++ b/kubernetes/apps/default/searxng/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app searxng
-  namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/external
   dependsOn:
@@ -18,20 +14,16 @@ spec:
       namespace: external-secrets
     - name: volsync
       namespace: volsync-system
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/default/searxng/app
   postBuild:
     substitute:
       APP: *app
       GATUS_SUBDOMAIN: search
       GATUS_PATH: /stats
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/default/spoolman/ks.yaml
+++ b/kubernetes/apps/default/spoolman/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app spoolman
-  namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/guarded
     - ../../../../components/volsync
@@ -23,13 +19,9 @@ spec:
     substitute:
       APP: *app
       GATUS_SUBDOMAIN: fil
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/default/vaultwarden/ks.yaml
+++ b/kubernetes/apps/default/vaultwarden/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app vaultwarden
-  namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/external
     - ../../../../components/volsync
@@ -27,13 +23,9 @@ spec:
       GATUS_SUBDOMAIN: pw
       GATUS_PATH: /alive
       VOLSYNC_CAPACITY: 2Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/external-secrets/external-secrets/ks.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/ks.yaml
@@ -4,16 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app external-secrets
-  namespace: &namespace external-secrets
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: *app
-      namespace: *namespace
   healthCheckExprs:
     - apiVersion: external-secrets.io/v1
       kind: ClusterSecretStore
@@ -21,13 +12,9 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/external-secrets/external-secrets/app
-  postBuild:
-    substituteFrom:
-      - kind: Secret
-        name: cluster-secrets
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/external-secrets/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/kustomization.yaml
@@ -5,5 +5,7 @@ kind: Kustomization
 namespace: external-secrets
 components:
   - ../../components/common
+replacements:
+  - path: ../../components/replacements/ks.yaml
 resources:
   - ./external-secrets/ks.yaml

--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -27,9 +27,6 @@ spec:
         ref: "refs/heads/main"
         path: kubernetes/flux/cluster
         interval: 1h
-      commonMetadata:
-        labels:
-          app.kubernetes.io/name: flux
       kustomize:
         patches:
           - # Increase the number of workers

--- a/kubernetes/apps/flux-system/flux-instance/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/ks.yaml
@@ -4,24 +4,14 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app flux-instance
-  namespace: &namespace flux-system
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: flux-operator
-      namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/flux-system/flux-instance/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/flux-system/flux-operator/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/ks.yaml
@@ -4,25 +4,12 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app flux-operator
-  namespace: &namespace flux-system
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: *app
-      namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/flux-system/flux-operator/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/flux-system/headlamp/ks.yaml
+++ b/kubernetes/apps/flux-system/headlamp/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app headlamp
-  namespace: &namespace flux-system
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/guarded
   dependsOn:
@@ -16,19 +12,15 @@ spec:
       namespace: external-secrets
     - name: openebs
       namespace: openebs-system
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/flux-system/headlamp/app
   postBuild:
     substitute:
       APP: *app
       GATUS_SUBDOMAIN: k8s
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/flux-system/kustomization.yaml
+++ b/kubernetes/apps/flux-system/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 namespace: flux-system
 components:
   - ../../components/common
+replacements:
+  - path: ../../components/replacements/ks.yaml
 resources:
   - ./flux-instance/ks.yaml
   - ./flux-operator/ks.yaml

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -4,21 +4,12 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app cilium
-  namespace: &namespace kube-system
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/cilium/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/kube-system/coredns/ks.yaml
+++ b/kubernetes/apps/kube-system/coredns/ks.yaml
@@ -4,21 +4,12 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app coredns
-  namespace: &namespace kube-system
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/coredns/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/kube-system/csi-driver-nfs/ks.yaml
+++ b/kubernetes/apps/kube-system/csi-driver-nfs/ks.yaml
@@ -4,21 +4,12 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app csi-driver-nfs
-  namespace: &namespace kube-system
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/csi-driver-nfs/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/kube-system/descheduler/ks.yaml
+++ b/kubernetes/apps/kube-system/descheduler/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app descheduler
-  namespace: &namespace kube-system
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/descheduler/app
   prune: true
@@ -16,5 +12,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/kube-system/generic-device-plugin/ks.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app generic-device-plugin
-  namespace: &namespace kube-system
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/generic-device-plugin/app
   prune: true
@@ -16,4 +12,3 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 namespace: kube-system
 components:
   - ../../components/common
+replacements:
+  - path: ../../components/replacements/ks.yaml
 resources:
   - ./cilium/ks.yaml
   - ./coredns/ks.yaml

--- a/kubernetes/apps/kube-system/metrics-server/ks.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/ks.yaml
@@ -4,21 +4,12 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app metrics-server
-  namespace: &namespace kube-system
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/metrics-server/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/kube-system/nvidia-device-plugin/ks.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/ks.yaml
@@ -4,16 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app nvidia-device-plugin
-  namespace: &namespace kube-system
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: *app
-      namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/kube-system/nvidia-device-plugin/app
   prune: true
@@ -21,4 +12,3 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace

--- a/kubernetes/apps/kube-system/reloader/ks.yaml
+++ b/kubernetes/apps/kube-system/reloader/ks.yaml
@@ -4,21 +4,12 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app reloader
-  namespace: &namespace kube-system
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/reloader/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
@@ -6,14 +6,6 @@ metadata:
   name: &app snapshot-controller
   namespace: &namespace kube-system
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: *app
-      namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/kube-system/snapshot-controller/app
   prune: true
@@ -21,4 +13,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/kube-system/spegel/ks.yaml
+++ b/kubernetes/apps/kube-system/spegel/ks.yaml
@@ -4,21 +4,12 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app spegel
-  namespace: &namespace kube-system
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/spegel/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/media/bazarr/ks.yaml
+++ b/kubernetes/apps/media/bazarr/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app bazarr
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/guarded
     - ../../../../components/keda/nfs-scaler
@@ -22,19 +18,15 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/media/bazarr/app
   postBuild:
     substitute:
       APP: *app
       GATUS_PATH: /health
       VOLSYNC_CAPACITY: 1Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace

--- a/kubernetes/apps/media/cross-seed/ks.yaml
+++ b/kubernetes/apps/media/cross-seed/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app cross-seed
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     # - ../../../../components/keda/nfs-scaler
     - ../../../../components/volsync
@@ -27,13 +23,9 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/media/flaresolverr/ks.yaml
+++ b/kubernetes/apps/media/flaresolverr/ks.yaml
@@ -4,20 +4,15 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app flaresolverr
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: prowlarr
       namespace: media
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/media/flaresolverr/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/media/imagemaid/ks.yaml
+++ b/kubernetes/apps/media/imagemaid/ks.yaml
@@ -4,30 +4,21 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app imagemaid
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: external-secrets
       namespace: external-secrets
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: plex
-      namespace: *namespace
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/media/imagemaid/app
   postBuild:
     substitute:
       APP: *app
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/media/jellyfin/ks.yaml
+++ b/kubernetes/apps/media/jellyfin/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app jellyfin
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/guarded
     - ../../../../components/keda/nfs-scaler
@@ -28,15 +24,11 @@ spec:
       GATUS_PATH: /health
       GATUS_SUBDOMAIN: plx
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -44,16 +36,11 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app jellyfin-tools
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: external-secrets
       namespace: external-secrets
     - name: jellyfin
-      namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/media/jellyfin/tools
   prune: true
@@ -61,5 +48,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/media/jellyseerr/ks.yaml
+++ b/kubernetes/apps/media/jellyseerr/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app jellyseerr
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/external
     - ../../../../components/volsync
@@ -27,12 +23,8 @@ spec:
       GATUS_PATH: /api/v1/status
       GATUS_SUBDOMAIN: req
       VOLSYNC_CAPACITY: 1Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace

--- a/kubernetes/apps/media/kometa/ks.yaml
+++ b/kubernetes/apps/media/kometa/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app kometa
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   dependsOn:
@@ -17,23 +13,18 @@ spec:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: plex
-      namespace: *namespace
     - name: volsync
       namespace: volsync-system
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/media/kometa/app
   postBuild:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 15Gi
       VOLSYNC_CACHE_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 namespace: media
 components:
   - ../../components/common
+replacements:
+  - path: ../../components/replacements/ks.yaml
 resources:
   - ./bazarr/ks.yaml
   - ./cross-seed/ks.yaml

--- a/kubernetes/apps/media/maintainerr/ks.yaml
+++ b/kubernetes/apps/media/maintainerr/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app maintainerr
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/guarded
     - ../../../../components/volsync
@@ -17,18 +13,14 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/media/maintainerr/app
   postBuild:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 1Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace

--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app plex
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/external
     - ../../../../components/keda/nfs-scaler
@@ -20,7 +16,7 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/media/plex/app
   postBuild:
     substitute:
@@ -30,12 +26,8 @@ spec:
       VOLSYNC_CAPACITY: 120Gi
       VOLSYNC_CACHE_CAPACITY: 40Gi
       VOLSYNC_SCHEDULE: "0 1 * * *"
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app prowlarr
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/guarded
     - ../../../../components/volsync
@@ -19,20 +15,16 @@ spec:
       namespace: volsync-system
     - name: rook-ceph-cluster
       namespace: rook-ceph
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/media/prowlarr/app
   postBuild:
     substitute:
       APP: *app
       GATUS_PATH: /ping
       VOLSYNC_CAPACITY: 1Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/media/qbittorrent/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app qbittorrent
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/guarded
     - ../../../../components/keda/nfs-scaler
@@ -31,12 +27,8 @@ spec:
       APP: *app
       GATUS_SUBDOMAIN: qb
       VOLSYNC_CAPACITY: 1Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app radarr
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/guarded
     - ../../../../components/keda/nfs-scaler
@@ -22,19 +18,15 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/media/radarr/app
   postBuild:
     substitute:
       APP: *app
       GATUS_PATH: /ping
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace

--- a/kubernetes/apps/media/recyclarr/ks.yaml
+++ b/kubernetes/apps/media/recyclarr/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app recyclarr
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   dependsOn:
@@ -17,10 +13,8 @@ spec:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: radarr
-      namespace: *namespace
     - name: sonarr
-      namespace: *namespace
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/media/recyclarr/app
   postBuild:
     substitute:
@@ -31,5 +25,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: true

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app sonarr
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/guarded
     - ../../../../components/keda/nfs-scaler
@@ -22,19 +18,15 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/media/sonarr/app
   postBuild:
     substitute:
       APP: *app
       GATUS_PATH: /ping
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace

--- a/kubernetes/apps/media/tautulli/ks.yaml
+++ b/kubernetes/apps/media/tautulli/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app tautulli
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/guarded
     - ../../../../components/volsync
@@ -24,12 +20,8 @@ spec:
       APP: *app
       GATUS_PATH: /status
       VOLSYNC_CAPACITY: 4Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace

--- a/kubernetes/apps/media/threadfin/ks.yaml
+++ b/kubernetes/apps/media/threadfin/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app threadfin
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
     - ../../../../components/gatus/guarded
@@ -17,7 +13,7 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/media/threadfin/app
   postBuild:
     substitute:
@@ -25,13 +21,9 @@ spec:
       VOLSYNC_CAPACITY: 5Gi
       GATUS_SUBDOMAIN: iptv
       GATUS_PATH: /
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: true

--- a/kubernetes/apps/media/tqm/ks.yaml
+++ b/kubernetes/apps/media/tqm/ks.yaml
@@ -4,14 +4,9 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app tqm
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: qbittorrent
-      namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/media/tqm/app
   postBuild:
@@ -23,5 +18,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/media/ytptube/ks.yaml
+++ b/kubernetes/apps/media/ytptube/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app ytptube
-  namespace: &namespace media
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/guarded
     - ../../../../components/keda/nfs-scaler
@@ -22,7 +18,7 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/media/ytptube/app
   postBuild:
     substitute:
@@ -30,12 +26,8 @@ spec:
       GATUS_PATH: /api/ping
       GATUS_SUBDOMAIN: ytdl
       VOLSYNC_CAPACITY: 1Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace

--- a/kubernetes/apps/network/external/ks.yaml
+++ b/kubernetes/apps/network/external/ks.yaml
@@ -4,23 +4,14 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app external-external-dns
-  namespace: &namespace network
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/network/external/external-dns
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: true
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
@@ -28,23 +19,14 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app cloudflared
-  namespace: &namespace network
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/network/external/cloudflared
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
@@ -52,24 +34,15 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app external-ingress-nginx
-  namespace: &namespace network
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: cert-manager-tls
       namespace: cert-manager
   interval: 1h
   path: ./kubernetes/apps/network/external/ingress-nginx
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/network/internal/ks.yaml
+++ b/kubernetes/apps/network/internal/ks.yaml
@@ -4,26 +4,17 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app internal-ingress-nginx
-  namespace: &namespace network
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: cert-manager-tls
       namespace: cert-manager
   interval: 1h
   path: ./kubernetes/apps/network/internal/ingress-nginx
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
@@ -31,21 +22,12 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app k8s-gateway
-  namespace: &namespace network
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/network/internal/k8s-gateway
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 namespace: network
 components:
   - ../../components/common
+replacements:
+  - path: ../../components/replacements/ks.yaml
 resources:
   - ./external/ks.yaml
   - ./internal/ks.yaml

--- a/kubernetes/apps/network/proxy/ks.yaml
+++ b/kubernetes/apps/network/proxy/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app proxy
-  namespace: &namespace network
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   interval: 1h
   dependsOn:
     - name: cert-manager-tls
@@ -19,13 +15,10 @@ spec:
   postBuild:
     substituteFrom:
       - kind: Secret
-        name: cluster-secrets
-      - kind: Secret
         name: proxy-secrets
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/network/tailscale/ks.yaml
+++ b/kubernetes/apps/network/tailscale/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app tailscale
-  namespace: &namespace network
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: external-secrets
       namespace: external-secrets
@@ -19,7 +15,6 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: true
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
@@ -27,14 +22,9 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app tailscale-configs
-  namespace: &namespace network
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: tailscale
-      namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/network/tailscale/configs
   postBuild:
@@ -46,5 +36,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: true

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/ks.yaml
@@ -4,21 +4,12 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app blackbox-exporter
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/observability/exporters/blackbox-exporter/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/observability/exporters/dcgm-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/dcgm-exporter/ks.yaml
@@ -4,24 +4,15 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app dcgm-exporter
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: nvidia-device-plugin
       namespace: kube-system
   interval: 1h
   path: ./kubernetes/apps/observability/exporters/dcgm-exporter/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/observability/exporters/jellyseerr-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/jellyseerr-exporter/ks.yaml
@@ -4,22 +4,17 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app jellyseerr-exporter
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: external-secrets
       namespace: external-secrets
     - name: jellyseerr
       namespace: media
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/observability/exporters/jellyseerr-exporter/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/observability/exporters/plex-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/plex-exporter/ks.yaml
@@ -4,26 +4,17 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app plex-exporter
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: external-secrets
       namespace: external-secrets
     - name: plex
       namespace: media
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/observability/exporters/plex-exporter/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/observability/exporters/prowlarr-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/prowlarr-exporter/ks.yaml
@@ -4,22 +4,17 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app prowlarr-exporter
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: external-secrets
       namespace: external-secrets
     - name: prowlarr
       namespace: media
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/observability/exporters/prowlarr-exporter/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/observability/exporters/qbittorrent-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/qbittorrent-exporter/ks.yaml
@@ -4,20 +4,15 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app qbittorrent-exporter
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: qbittorrent
       namespace: media
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/observability/exporters/qbittorrent-exporter/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/observability/exporters/radarr-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/radarr-exporter/ks.yaml
@@ -4,22 +4,17 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app radarr-exporter
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: external-secrets
       namespace: external-secrets
     - name: radarr
       namespace: media
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/observability/exporters/radarr-exporter/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/observability/exporters/snmp-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/snmp-exporter/ks.yaml
@@ -4,24 +4,15 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app snmp-exporter-synology
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: external-secrets
       namespace: external-secrets
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/observability/exporters/snmp-exporter/synology
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/observability/exporters/sonarr-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/sonarr-exporter/ks.yaml
@@ -4,22 +4,17 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app sonarr-exporter
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: external-secrets
       namespace: external-secrets
     - name: sonarr
       namespace: media
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/observability/exporters/sonarr-exporter/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/observability/exporters/tautulli-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/tautulli-exporter/ks.yaml
@@ -4,22 +4,17 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app tautulli-exporter
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: external-secrets
       namespace: external-secrets
     - name: tautulli
       namespace: media
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/observability/exporters/tautulli-exporter/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/observability/fluent-bit/ks.yaml
+++ b/kubernetes/apps/observability/fluent-bit/ks.yaml
@@ -4,17 +4,12 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app fluent-bit
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/observability/fluent-bit/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/observability/gatus/ks.yaml
+++ b/kubernetes/apps/observability/gatus/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app gatus
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/cnpg
   dependsOn:
@@ -16,16 +12,13 @@ spec:
       namespace: external-secrets
     - name: cnpg-cluster
       namespace: database
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/observability/gatus/app
   postBuild:
     substitute:
       APP: *app
       GATUS_SUBDOMAIN: status
       CNPG_NAME: &postgresAppName postgres16
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   healthChecks:
     - apiVersion: &postgresVersion postgresql.cnpg.io/v1
       kind: &postgresKind Cluster
@@ -41,5 +34,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
-  wait: false # no flux ks dependents
+  wait: false

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -3,11 +3,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app grafana
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/cnpg
     - ../../../../components/gatus/guarded
@@ -16,15 +12,12 @@ spec:
       namespace: external-secrets
     - name: cnpg-cluster
       namespace: database
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/observability/grafana/app
   postBuild:
     substitute:
       APP: *app
       CNPG_NAME: &postgresAppName postgres16
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   healthChecks:
     - apiVersion: &postgresVersion postgresql.cnpg.io/v1
       kind: &postgresKind Cluster
@@ -40,5 +33,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/observability/karma/ks.yaml
+++ b/kubernetes/apps/observability/karma/ks.yaml
@@ -4,27 +4,18 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app karma
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: victoria-metrics-stack
-      namespace: *namespace
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/observability/karma/app
   postBuild:
     substitute:
       GATUS_PATH: /health
       GATUS_SUBDOMAIN: am
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/observability/keda/ks.yaml
+++ b/kubernetes/apps/observability/keda/ks.yaml
@@ -4,16 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app keda
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: *app
-      namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/observability/keda/app
   prune: true
@@ -21,4 +12,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/observability/kromgo/ks.yaml
+++ b/kubernetes/apps/observability/kromgo/ks.yaml
@@ -4,29 +4,20 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app kromgo
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/external
   dependsOn:
     - name: victoria-metrics-stack
-      namespace: observability
   interval: 1h
   path: ./kubernetes/apps/observability/kromgo/app
   postBuild:
     substitute:
       APP: *app
       GATUS_PATH: /talos_version
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 namespace: observability
 components:
   - ../../components/common
+replacements:
+  - path: ../../components/replacements/ks.yaml
 resources:
   - ./exporters
   - ./fluent-bit/ks.yaml

--- a/kubernetes/apps/observability/silence-operator/ks.yaml
+++ b/kubernetes/apps/observability/silence-operator/ks.yaml
@@ -4,16 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app silence-operator
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: *app
-      namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/observability/silence-operator/app
   prune: true
@@ -21,21 +12,16 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
+  wait: true
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app silence-operator-silences
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: silence-operator
-      namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/observability/silence-operator/silences
   prune: true
@@ -43,5 +29,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/observability/unpoller/ks.yaml
+++ b/kubernetes/apps/observability/unpoller/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app unpoller
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: external-secrets
       namespace: external-secrets
@@ -17,13 +13,9 @@ spec:
   postBuild:
     substitute:
       APP: *app
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/observability/victoria-logs/ks.yaml
+++ b/kubernetes/apps/observability/victoria-logs/ks.yaml
@@ -4,24 +4,16 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app victoria-logs
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/observability/victoria-logs/app
   postBuild:
     substitute:
       APP: vm
       GATUS_SUBDOMAIN: logs
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/observability/victoria-metrics/ks.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/ks.yaml
@@ -4,26 +4,18 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app victoria-metrics-stack
-  namespace: &namespace observability
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: external-secrets
       namespace: external-secrets
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/observability/victoria-metrics/app
   postBuild:
     substitute:
       APP: vm
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/openebs-system/kustomization.yaml
+++ b/kubernetes/apps/openebs-system/kustomization.yaml
@@ -5,5 +5,7 @@ kind: Kustomization
 namespace: openebs-system
 components:
   - ../../components/common
+replacements:
+  - path: ../../components/replacements/ks.yaml
 resources:
   - ./openebs/ks.yaml

--- a/kubernetes/apps/openebs-system/openebs/ks.yaml
+++ b/kubernetes/apps/openebs-system/openebs/ks.yaml
@@ -4,16 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app openebs
-  namespace: &namespace openebs-system
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: *app
-      namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/openebs-system/openebs/app
   prune: true
@@ -21,4 +12,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/rook-ceph/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/kustomization.yaml
@@ -5,5 +5,7 @@ kind: Kustomization
 namespace: rook-ceph
 resources:
   - ./rook-ceph/ks.yaml
+replacements:
+  - path: ../../components/replacements/ks.yaml
 components:
   - ../../components/common

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chartRef:
     kind: OCIRepository
     name: rook-ceph
-  interval: 30m
+  interval: 1h
   values:
     crds:
       enabled: true

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chartRef:
     kind: OCIRepository
     name: *app
-  interval: 30m
+  interval: 1h
   dependsOn:
   - name: snapshot-controller
     namespace: kube-system

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -4,38 +4,24 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app rook-ceph
-  namespace: &namespace rook-ceph
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: rook-ceph-operator
-      namespace: *namespace
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/rook-ceph/rook-ceph/app
   prune: false
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
+  wait: true
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app rook-ceph-cluster
-  namespace: &namespace rook-ceph
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
-    - name: rook-ceph
-      namespace: *namespace
+    - name: &namespace rook-ceph
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
@@ -43,21 +29,20 @@ spec:
       namespace: *namespace
     - apiVersion: ceph.rook.io/v1
       kind: CephCluster
-      name: rook-ceph
+      name: *namespace
       namespace: *namespace
   healthCheckExprs:
     - apiVersion: ceph.rook.io/v1
       kind: CephCluster
       failed: status.ceph.health == 'HEALTH_ERR'
       current: status.ceph.health in ['HEALTH_OK', 'HEALTH_WARN']
-  interval: 30m
+  interval: 1h
   path: ./kubernetes/apps/rook-ceph/rook-ceph/cluster
   prune: false
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false
   patches:
     - # modify ServiceMonitor to only scrape the mgr service on primary node

--- a/kubernetes/apps/system-upgrade/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/kustomization.yaml
@@ -5,5 +5,7 @@ kind: Kustomization
 namespace: system-upgrade
 components:
   - ../../components/common
+replacements:
+  - path: ../../components/replacements/ks.yaml
 resources:
   - ./tuppr/ks.yaml

--- a/kubernetes/apps/system-upgrade/tuppr/ks.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/ks.yaml
@@ -4,16 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app tuppr
-  namespace: &namespace system-upgrade
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: *app
-      namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/system-upgrade/tuppr/app
   prune: true
@@ -21,21 +12,16 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
+  wait: true
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app tuppr-upgrades
-  namespace: &namespace system-upgrade
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: tuppr
-      namespace: system-upgrade
   interval: 1h
   path: ./kubernetes/apps/system-upgrade/tuppr/upgrades
   prune: true
@@ -43,5 +29,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/volsync-system/kustomization.yaml
+++ b/kubernetes/apps/volsync-system/kustomization.yaml
@@ -5,5 +5,7 @@ kind: Kustomization
 namespace: volsync-system
 components:
   - ../../components/common
+replacements:
+  - path: ../../components/replacements/ks.yaml
 resources:
   - ./volsync/ks.yaml

--- a/kubernetes/apps/volsync-system/volsync/ks.yaml
+++ b/kubernetes/apps/volsync-system/volsync/ks.yaml
@@ -4,11 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app volsync
-  namespace: &namespace volsync-system
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/keda/nfs-bkup-scaler
   dependsOn:
@@ -18,22 +14,14 @@ spec:
       namespace: openebs-system
     - name: snapshot-controller
       namespace: kube-system
-  healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: *app
-      namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/volsync-system/volsync/app
   postBuild:
     substitute:
       APP: *app
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/components/replacements/ks.yaml
+++ b/kubernetes/components/replacements/ks.yaml
@@ -1,0 +1,27 @@
+---
+- # Apply targetNamespace to all Flux Kustomizations
+  source:
+    kind: Namespace
+    fieldPath: metadata.name
+  targets:
+    - select:
+        kind: Kustomization
+        group: kustomize.toolkit.fluxcd.io
+      fieldPaths:
+        - spec.targetNamespace
+      options:
+        create: true
+
+# Apply postBuild.substituteFrom to all Flux Kustomizations
+- source:
+    kind: Secret
+    name: cluster-secrets
+    fieldPath: metadata.name
+  targets:
+    - select:
+        kind: Kustomization
+        group: kustomize.toolkit.fluxcd.io
+      fieldPaths:
+        - spec.postBuild.substituteFrom.[].name
+      options:
+        create: true

--- a/kubernetes/components/replacements/ks.yaml
+++ b/kubernetes/components/replacements/ks.yaml
@@ -22,6 +22,6 @@
         kind: Kustomization
         group: kustomize.toolkit.fluxcd.io
       fieldPaths:
-        - spec.postBuild.substituteFrom.[].name
+        - spec.postBuild.substituteFrom.[kind=Secret].name
       options:
         create: true

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -10,16 +10,16 @@ spec:
     provider: sops
     secretRef:
       name: sops-age-secret
+  deletionPolicy: WaitForTermination
   interval: 1h
   path: ./kubernetes/apps
   prune: true
-  retryInterval: 2m
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
   patches:
-    - # Add Sops decryption to all Kustomizations
+    - # Add HelmRelease defaults to all Kustomizations
       patch: |-
         apiVersion: kustomize.toolkit.fluxcd.io/v1
         kind: Kustomization
@@ -28,28 +28,7 @@ spec:
         spec:
           decryption:
             provider: sops
-      target:
-        group: kustomize.toolkit.fluxcd.io
-        kind: Kustomization
-    - # Add default timings to all Kustomizations
-      patch: |-
-        apiVersion: kustomize.toolkit.fluxcd.io/v1
-        kind: Kustomization
-        metadata:
-          name: not-used
-        spec:
-          retryInterval: 2m
-          timeout: 10m
-      target:
-        group: kustomize.toolkit.fluxcd.io
-        kind: Kustomization
-    - # Add HelmRelease defaults to all Kustomizations
-      patch: |-
-        apiVersion: kustomize.toolkit.fluxcd.io/v1
-        kind: Kustomization
-        metadata:
-          name: not-used
-        spec:
+          deletionPolicy: WaitForTermination
           patches:
             - patch: |-
                 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -63,7 +42,6 @@ spec:
                       name: RetryOnFailure
                     remediation:
                       retries: -1
-                  timeout: 10m
                   upgrade:
                     cleanupOnFail: true
                     crds: CreateReplace

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -42,6 +42,9 @@ spec:
                       name: RetryOnFailure
                     remediation:
                       retries: -1
+                  rollback:
+                    cleanupOnFail: true
+                    recreate: true
                   upgrade:
                     cleanupOnFail: true
                     crds: CreateReplace


### PR DESCRIPTION
Noisy events log, and I noticed onedr0p modifying his flux kustomization settings in PR-9896...

   - consolidate ks patch for children
   - remove timeouts and retryInterval (not needed with 2.7.0 and patch to cancel pending ks healthchecks?)
   - add WaitForTermination deletionPolicy (fix for alerts on ks removal?)

