### PR TITLE
feat(webhook): add app

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -24,3 +24,4 @@ resources:
   - ./searxng/ks.yaml
   - ./spoolman/ks.yaml
   - ./vaultwarden/ks.yaml
+  - ./webhook/ks.yaml

--- a/kubernetes/apps/default/webhook/app/externalsecret.yaml
+++ b/kubernetes/apps/default/webhook/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name webhook-secrets
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless-secret-store
+  target:
+    name: *name
+    template:
+      data:
+        KOMETA_PUSHOVER_URL: pover://{{ .PUSHOVER_USER_KEY }}@{{ .PUSHOVER_PLEX_TOKEN }}
+  dataFrom:
+    - extract:
+        key: /healthchecks

--- a/kubernetes/apps/default/webhook/app/helmrelease.yaml
+++ b/kubernetes/apps/default/webhook/app/helmrelease.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app webhook
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    controllers:
+      *app :
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-operations/webhook
+              tag: 2.8.2@sha256:22bcdc2e1bfa62901616008e97d5d3150a29d721c1e2907297aa1e70b93e1cb7
+            env:
+              WEBHOOK__PORT: &port 80
+              TZ: ${TIMEZONE}
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 100m
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: *port
+    ingress:
+      app:
+        className: internal
+        hosts:
+          - host: "${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+    persistence:
+      config:
+        type: configMap
+        name: webhook-configmap
+        defaultMode: 0775
+        globalMounts:
+          - readOnly: true

--- a/kubernetes/apps/default/webhook/app/kustomization.yaml
+++ b/kubernetes/apps/default/webhook/app/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+configMapGenerator:
+  - name: webhook-configmap
+    files:
+      - hooks.yaml=./resources/hooks.yaml
+      - kometa-pushover.sh=./resources/kometa-pushover.sh
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/default/webhook/app/ocirepository.yaml
+++ b/kubernetes/apps/default/webhook/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: webhook
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.3.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/webhook/app/resources/hooks.yaml
+++ b/kubernetes/apps/default/webhook/app/resources/hooks.yaml
@@ -1,0 +1,32 @@
+- id: kometa-pushover
+  execute-command: /config/kometa-pushover.sh
+  command-working-directory: /config
+  pass-environment-to-command:
+    # Pushover URL – pulled from an environment variable (e.g., in your container)
+    - envname: KOMETA_PUSHOVER_URL
+      source: string
+      name: '{{ getenv "KOMETA_PUSHOVER_URL" }}'
+    # Kometa event type (e.g. "collection_error", "global_error")
+    - envname: KOMETA_EVENT_TYPE
+      source: payload
+      name: event
+    # Global error message text
+    - envname: KOMETA_MESSAGE
+      source: payload
+      name: message
+    # Library context (used by library_error, collection_error)
+    - envname: KOMETA_LIBRARY_NAME
+      source: payload
+      name: library_name
+    # Collection context (used by collection_error)
+    - envname: KOMETA_COLLECTION_NAME
+      source: payload
+      name: collection_name
+    # Playlist context (used by playlist_error)
+    - envname: KOMETA_PLAYLIST_NAME
+      source: payload
+      name: playlist_name
+    # Optional — the Kometa app URL if your webhook payload includes it
+    - envname: KOMETA_APPLICATION_URL
+      source: payload
+      name: application_url

--- a/kubernetes/apps/default/webhook/app/resources/kometa-pushover.sh
+++ b/kubernetes/apps/default/webhook/app/resources/kometa-pushover.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function notify() {
+    local event="${KOMETA_EVENT_TYPE:-}"
+    local url="${KOMETA_APPLICATION_URL:-https://kometa.wiki}"
+
+    # Ignore non-error events
+    case "${event}" in
+        "global_error"|"library_error"|"collection_error"|"playlist_error") ;;
+        *)
+            echo "[INFO] Ignoring non-error event: ${event:-unknown}"
+            return 0
+            ;;
+    esac
+
+    local pushover_title pushover_message pushover_priority pushover_url pushover_url_title
+    pushover_url="${url}"
+    pushover_url_title="View Kometa"
+    pushover_priority="high"
+
+    if [[ "${event}" == "global_error" ]]; then
+        printf -v pushover_title "Kometa Global Error"
+        printf -v pushover_message "<b>Global Error</b><br><small>%s</small>" \
+            "${KOMETA_MESSAGE}"
+    elif [[ "${event}" == "library_error" ]]; then
+        printf -v pushover_title "Kometa Library Error"
+        printf -v pushover_message "<b>Library:</b> %s<br><small>%s</small>" \
+            "${KOMETA_LIBRARY_NAME}" \
+            "${KOMETA_MESSAGE}"
+    elif [[ "${event}" == "collection_error" ]]; then
+        printf -v pushover_title "Kometa Collection Error"
+        printf -v pushover_message "<b>Library:</b> %s<br><b>Collection:</b> %s<br><small>%s</small>" \
+            "${KOMETA_LIBRARY_NAME}" \
+            "${KOMETA_COLLECTION_NAME}" \
+            "${KOMETA_MESSAGE}"
+    elif [[ "${event}" == "playlist_error" ]]; then
+        printf -v pushover_title "Kometa Playlist Error"
+        printf -v pushover_message "<b>Playlist:</b> %s<br><small>%s</small>" \
+            "${KOMETA_PLAYLIST_NAME}" \
+            "${KOMETA_MESSAGE}"
+    fi
+
+    apprise -vv --title "${pushover_title}" --body "${pushover_message}" --input-format html \
+        "${KOMETA_PUSHOVER_URL}?url=${pushover_url}&url_title=${pushover_url_title}&priority=${pushover_priority}&format=html"
+}
+
+function main() {
+    notify
+}
+
+main "$@"

--- a/kubernetes/apps/default/webhook/ks.yaml
+++ b/kubernetes/apps/default/webhook/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app webhook
+spec:
+  components:
+    - ../../../../components/gatus/external
+  dependsOn:
+    - name: external-secrets
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/default/webhook/app
+  postBuild:
+    substitute:
+      APP: *app
+      GATUS_SUBDOMAIN: hook
+      GATUS_PATH: /alive
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
### Flexible webhook to send notifications to pushover
Some common use cases include sonarr/radarr/jellyseer/plex
This commit starts by trying to add a Kometa → Pushover integration using a custom webhook and Bash script.
The webhook forwards Kometa error events (`global_error`, `library_error`, `collection_error`, `playlist_error`) to Pushover via Apprise, providing immediate alerts for failed syncs or metadata issues.