### PR TITLE
Revert "fix(container): update image ghcr.io/victoriametrics/helm-charts/victoria-metrics-k8s-stack ( 0.61.0 ➔ 0.61.2 )"

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.61.2
+    tag: 0.61.0
   url: oci://ghcr.io/victoriametrics/helm-charts/victoria-metrics-k8s-stack


### PR DESCRIPTION
Reverts tscibilia/home-ops#940

### RecordingRulesNoData InfoInhibtor
- cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile (kube-scheduler.rules) produces no data
- count:up0 (kube-prometheus-general.rules) produces no data
- node_namespace_pod_container:container_memory_swap (k8s.rules.container_memory_swap) produces no data
- cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile (kube-scheduler.rules) produces no data
- cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile (kube-scheduler.rules) produces no data