### PR TITLE
Revert "feat(container): update image ghcr.io/jellyfin/jellyfin ( 10.10.7 ➔ 10.11.0 )"

### DIFF
--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/jellyfin/jellyfin
-              tag: 10.11.0@sha256:519b02989eafcc4bdb558bdc7014c2395c19608e5c2d7ed99a5f3edd0c75f7ef
+              tag: 10.10.7@sha256:e4d1dc5374344446a3a78e43dd211247f22afba84ea2e5a13cbe1a94e1ff2141
             env:
               TZ: ${TIMEZONE}
             probes:


### PR DESCRIPTION
Reverts tscibilia/home-ops#1000

Getting a CrashLoopBackOff due to `SQLite Error 1: 'no such table: ActivityLog'`. The migration `20250420070000_MigrateActivityLogDb` is trying to migrate the ActivityLog table, but it doesn't exist in the database.