### PR TITLE
Revert "fix(container): update image ghcr.io/goauthentik/helm-charts/authentik ( 2025.10.0 ➔ 2025.10.1 )"

### DIFF
--- a/kubernetes/apps/default/authentik/app/ocirepository.yaml
+++ b/kubernetes/apps/default/authentik/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 2025.10.1
+    tag: 2025.10.0
   url: oci://ghcr.io/goauthentik/helm-charts/authentik


### PR DESCRIPTION
Reverts tscibilia/home-ops#1070

---
Before (2025.10.0):
ak healthcheck would quickly return 0 (success) as soon as the container’s Django runtime initialized.
The worker could report healthy even while waiting for the main app to send startup signals.

After (2025.10.1):
The new “delayed startup signals” behavior means the worker holds back readiness until background tasks and signal receivers are registered.
During this delay, ak healthcheck exits non-zero — so your Kubernetes probe keeps failing.