### PR TITLE
fix(authentik): test split outposts

### DIFF
--- a/kubernetes/apps/default/authentik/app/referencegrant.yaml
+++ b/kubernetes/apps/default/authentik/app/referencegrant.yaml
@@ -25,3 +25,9 @@ spec:
     - group: ''
       kind: Service
       name: ak-outpost-authentik-embedded-outpost
+    - group: ''
+      kind: Service
+      name: authentik-outpost-internal
+    - group: ''
+      kind: Service
+      name: authentik-outpost-external

--- a/kubernetes/apps/default/authentik/ks.yaml
+++ b/kubernetes/apps/default/authentik/ks.yaml
@@ -41,3 +41,21 @@ spec:
     namespace: flux-system
   targetNamespace: default
   wait: false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app authentik-outposts
+spec:
+  dependsOn:
+    - name: authentik
+  interval: 1h
+  path: ./kubernetes/apps/default/authentik/outposts
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false

--- a/kubernetes/apps/default/authentik/outposts/externalsecret.yaml
+++ b/kubernetes/apps/default/authentik/outposts/externalsecret.yaml
@@ -1,0 +1,37 @@
+
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name authentik-outpost-external-token
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless-secret-store
+  target:
+    name: *name
+    template:
+      data:
+        token: "{{ .AUTHENTIK_OUTPOST_EXTERNAL_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: /authentik
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name authentik-outpost-internal-token
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless-secret-store
+  target:
+    name: *name
+    template:
+      data:
+        token: "{{ .AUTHENTIK_OUTPOST_INTERNAL_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: /authentik

--- a/kubernetes/apps/default/authentik/outposts/kustomization.yaml
+++ b/kubernetes/apps/default/authentik/outposts/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./outpost-external.yaml
+  - ./outpost-internal.yaml

--- a/kubernetes/apps/default/authentik/outposts/outpost-external.yaml
+++ b/kubernetes/apps/default/authentik/outposts/outpost-external.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authentik-outpost-external
+  namespace: default
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: authentik-outpost-external
+  ports:
+    - name: http
+      port: 9000
+      protocol: TCP
+      targetPort: http
+    - name: https
+      port: 9443
+      protocol: TCP
+      targetPort: https
+    - name: metrics
+      port: 9300
+      protocol: TCP
+      targetPort: metrics
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authentik-outpost-external
+  namespace: default
+  labels:
+    app.kubernetes.io/name: authentik-outpost-external
+    app.kubernetes.io/component: outpost
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: authentik-outpost-external
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: authentik-outpost-external
+        app.kubernetes.io/component: outpost
+    spec:
+      containers:
+        - name: outpost
+          image: ghcr.io/goauthentik/proxy:2025.10.2
+          env:
+            - name: AUTHENTIK_HOST
+              value: "http://authentik-server:9000"
+            - name: AUTHENTIK_INSECURE
+              value: "true"
+            - name: AUTHENTIK_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: authentik-outpost-external-token
+                  key: token
+          ports:
+            - name: http
+              containerPort: 9000
+              protocol: TCP
+            - name: https
+              containerPort: 9443
+              protocol: TCP
+            - name: metrics
+              containerPort: 9300
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: authentik-outpost-external
+  namespace: default
+spec:
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /outpost.goauthentik.io
+      backendRefs:
+        - name: authentik-outpost-external
+          port: 9000

--- a/kubernetes/apps/default/authentik/outposts/outpost-internal.yaml
+++ b/kubernetes/apps/default/authentik/outposts/outpost-internal.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authentik-outpost-internal
+  namespace: default
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: authentik-outpost-internal
+  ports:
+    - name: http
+      port: 9000
+      protocol: TCP
+      targetPort: http
+    - name: https
+      port: 9443
+      protocol: TCP
+      targetPort: https
+    - name: metrics
+      port: 9300
+      protocol: TCP
+      targetPort: metrics
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authentik-outpost-internal
+  namespace: default
+  labels:
+    app.kubernetes.io/name: authentik-outpost-internal
+    app.kubernetes.io/component: outpost
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: authentik-outpost-internal
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: authentik-outpost-internal
+        app.kubernetes.io/component: outpost
+    spec:
+      containers:
+        - name: outpost
+          image: ghcr.io/goauthentik/proxy:2025.10.2
+          env:
+            - name: AUTHENTIK_HOST
+              value: "http://authentik-server:9000"
+            - name: AUTHENTIK_INSECURE
+              value: "true"
+            - name: AUTHENTIK_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: authentik-outpost-internal-token
+                  key: token
+          ports:
+            - name: http
+              containerPort: 9000
+              protocol: TCP
+            - name: https
+              containerPort: 9443
+              protocol: TCP
+            - name: metrics
+              containerPort: 9300
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: authentik-outpost-internal
+  namespace: default
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /outpost.goauthentik.io
+      backendRefs:
+        - name: authentik-outpost-internal
+          port: 9000

--- a/kubernetes/apps/media/qbittorrent/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/ks.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &app qbittorrent
 spec:
   components:
-    - ../../../../components/ext-auth
+    - ../../../../components/ext-auth-internal
     - ../../../../components/keda/nfs-scaler
     - ../../../../components/volsync
   dependsOn:

--- a/kubernetes/components/ext-auth-external/kustomization.yaml
+++ b/kubernetes/components/ext-auth-external/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./securitypolicy.yaml

--- a/kubernetes/components/ext-auth-external/securitypolicy.yaml
+++ b/kubernetes/components/ext-auth-external/securitypolicy.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+# adapted from https://docs.goauthentik.io/docs/add-secure-apps/providers/proxy/server_envoy and https://github.com/authelia/authelia/blob/master/docs/content/integration/proxies/envoy.md#secure-route
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: "${APP}"
+spec:
+  extAuth:
+    failOpen: false
+    headersToExtAuth: ["cookie"]
+    http:
+      backendRefs:
+        - name: authentik-outpost-external
+          namespace: default
+          port: 9000
+      path: /outpost.goauthentik.io/auth/envoy
+      headersToBackend: ["set-cookie", "x-authentik-*", "authorization"]
+  targetRefs:
+    - group: "${EXT_AUTH_GROUP:-gateway.networking.k8s.io}"
+      kind: "${EXT_AUTH_KIND:-HTTPRoute}"
+      name: "${EXT_AUTH_TARGET:-${APP}}"

--- a/kubernetes/components/ext-auth-internal/kustomization.yaml
+++ b/kubernetes/components/ext-auth-internal/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./securitypolicy.yaml

--- a/kubernetes/components/ext-auth-internal/securitypolicy.yaml
+++ b/kubernetes/components/ext-auth-internal/securitypolicy.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+# adapted from https://docs.goauthentik.io/docs/add-secure-apps/providers/proxy/server_envoy and https://github.com/authelia/authelia/blob/master/docs/content/integration/proxies/envoy.md#secure-route
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: "${APP}"
+spec:
+  extAuth:
+    failOpen: false
+    headersToExtAuth: ["cookie"]
+    http:
+      backendRefs:
+        - name: authentik-outpost-internal
+          namespace: default
+          port: 9000
+      path: /outpost.goauthentik.io/auth/envoy
+      headersToBackend: ["set-cookie", "x-authentik-*", "authorization"]
+  targetRefs:
+    - group: "${EXT_AUTH_GROUP:-gateway.networking.k8s.io}"
+      kind: "${EXT_AUTH_KIND:-HTTPRoute}"
+      name: "${EXT_AUTH_TARGET:-${APP}}"


### PR DESCRIPTION
k8s-gateway is returning both gateway IPs:
192.168.5.241 (envoy-external)
192.168.5.231 (envoy-internal)

The Authentik outpost HTTPRoute (created by the ext-auth component) includes qb.t0m.co in its hostnames and references both gateways

The HTTPRoute is managed by Authentik itself (created by the embedded outpost). Since you're using the ext-auth component, it references both gateways. However, this Authentik route only matches path /outpost.goauthentik.io (for the forward auth endpoint), not /. So when you access https://qb.t0m.co/, envoy-external has no matching route and returns an error. The issue is that k8s-gateway sees hostnames across all routes and returns IPs for all gateways, regardless of path matching. 