### PR TITLE
feat(guacamole)!: add app to observability

### DIFF
--- a/kubernetes/apps/observability/guacamole/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/guacamole/app/externalsecret.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name guacamole-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless-secret-store
+  target:
+    name: *name
+    template:
+      data:
+        # PostgreSQL configuration
+        POSTGRES_HOSTNAME: "${CNPG_NAME:=postgres16}-rw.database.svc.cluster.local"
+        POSTGRES_PORT: "5432"
+        POSTGRES_DATABASE: "${APP}"
+        POSTGRES_USER: "${APP}"
+        POSTGRES_PASSWORD: "{{ .${APP}_postgres_password }}"
+        # Guacd daemon configuration
+        GUACD_HOSTNAME: guacd.observability.svc.cluster.local
+        GUACD_PORT: "4822"
+        # OpenID Connect (Authentik) configuration
+        OPENID_AUTHORIZATION_ENDPOINT: "https://auth.${SECRET_DOMAIN}/application/o/authorize/"
+        OPENID_JWKS_ENDPOINT: "https://auth.${SECRET_DOMAIN}/application/o/guacamole/jwks/"
+        OPENID_ISSUER: "https://auth.${SECRET_DOMAIN}/application/o/guacamole/"
+        OPENID_CLIENT_ID: "{{ .GUACAMOLE_OAUTH_CLIENT_ID }}"
+        OPENID_REDIRECT_URI: "https://${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}"
+  dataFrom:
+    - extract:
+        key: /guacamole
+    - extract:
+        key: /cnpg-users

--- a/kubernetes/apps/observability/guacamole/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/guacamole/app/helmrelease.yaml
@@ -1,0 +1,119 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app guacamole
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    controllers:
+      *app :
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          01-init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: "18"
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-initdb-secret"
+          02-initdb:
+            image:
+              repository: docker.io/guacamole/guacamole
+              tag: 1.6.0@sha256:f344085e618bb05e22b964b0208dbd06d3468275bac70206f93805245e067b40
+            envFrom:
+              - secretRef:
+                  name: guacamole-secret
+            command:
+              - /bin/sh
+              - -c
+              - /opt/guacamole/bin/initdb.sh --postgresql > /migrations/initdb.sql
+          03-changeowner:
+            image:
+              repository: docker.io/guacamole/guacamole
+              tag: 1.6.0@sha256:f344085e618bb05e22b964b0208dbd06d3468275bac70206f93805245e067b40
+            envFrom:
+              - secretRef:
+                  name: guacamole-secret
+            command:
+              - /bin/sh
+              - -c
+              - psql postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOSTNAME:$POSTGRES_PORT/$POSTGRES_DATABASE -c "ALTER SCHEMA public OWNER TO $POSTGRES_USER;" || true
+          04-migrate:
+            image:
+              repository: docker.io/guacamole/guacamole
+              tag: 1.6.0@sha256:f344085e618bb05e22b964b0208dbd06d3468275bac70206f93805245e067b40
+            envFrom:
+              - secretRef:
+                  name: guacamole-secret
+            command:
+              - /bin/sh
+              - -c
+              - psql postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOSTNAME:$POSTGRES_PORT/$POSTGRES_DATABASE -f /migrations/initdb.sql || true
+        containers:
+          app:
+            image:
+              repository: docker.io/guacamole/guacamole
+              tag: 1.6.0@sha256:f344085e618bb05e22b964b0208dbd06d3468275bac70206f93805245e067b40
+            env:
+              TZ: ${TIMEZONE:-UTC}
+              GUACAMOLE_HOME: /config
+              TOTP_ENABLED: "true"
+            envFrom:
+              - secretRef:
+                  name: guacamole-secret
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 250m
+                memory: 128Mi
+              limits:
+                memory: 2Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: &port 8080
+    route:
+      app:
+        annotations:
+          gatus.home-operations.com/endpoint: |-
+            conditions: ["[STATUS] == 200"]
+        hostnames: ["${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        type: emptyDir
+        advancedMounts:
+          *app :
+            app:
+              - path: /config
+      migrations:
+        type: emptyDir
+        advancedMounts:
+          *app :
+            02-initdb:
+              - path: /migrations
+            04-migrate:
+              - path: /migrations

--- a/kubernetes/apps/observability/guacamole/app/kustomization.yaml
+++ b/kubernetes/apps/observability/guacamole/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/observability/guacamole/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/guacamole/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: guacamole
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.4.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/observability/guacamole/guacd/helmrelease.yaml
+++ b/kubernetes/apps/observability/guacamole/guacd/helmrelease.yaml
@@ -1,0 +1,61 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app guacd
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    controllers:
+      *app :
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/guacamole/guacd
+              tag: 1.6.0@sha256:8974eaa9ba32f713daf311e7cc8cd7e4cdfba1edea39eed75524e78ef4b08f4f
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              runAsUser: 1000
+              runAsGroup: 1000
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: 4822
+    persistence:
+      home:
+        type: emptyDir
+        advancedMounts:
+          *app :
+            app:
+              - path: /home/guacd
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          *app :
+            app:
+              - path: /tmp

--- a/kubernetes/apps/observability/guacamole/guacd/kustomization.yaml
+++ b/kubernetes/apps/observability/guacamole/guacd/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/observability/guacamole/guacd/ocirepository.yaml
+++ b/kubernetes/apps/observability/guacamole/guacd/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: guacd
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.4.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/observability/guacamole/ks.yaml
+++ b/kubernetes/apps/observability/guacamole/ks.yaml
@@ -1,0 +1,59 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app guacamole-guacd
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/observability/guacamole/guacd
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: observability
+  wait: false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app guacamole
+spec:
+  components:
+    - ../../../../components/cnpg
+  dependsOn:
+    - name: secret-stores
+      namespace: external-secrets
+    - name: cnpg-cluster
+      namespace: database
+    - name: guacamole-guacd
+      namespace: observability
+  interval: 1h
+  path: ./kubernetes/apps/observability/guacamole/app
+  postBuild:
+    substitute:
+      APP: *app
+      GATUS_SUBDOMAIN: rdp
+      CNPG_NAME: &postgresAppName postgres16
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  healthChecks:
+    - apiVersion: &postgresVersion postgresql.cnpg.io/v1
+      kind: &postgresKind Cluster
+      name: *postgresAppName
+      namespace: database
+  healthCheckExprs:
+    - apiVersion: *postgresVersion
+      kind: *postgresKind
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: observability
+  wait: false

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ./fluent-bit/ks.yaml
   - ./gatus/ks.yaml
   - ./grafana/ks.yaml
+  - ./guacamole/ks.yaml
   - ./karma/ks.yaml
   - ./keda/ks.yaml
   - ./kite/ks.yaml


### PR DESCRIPTION
#### Dependencies & Flow:
- ✅ guacd deployed first, guacamole app depends on it
- ✅ Proper dependencies on secret-stores and cnpg-cluster
- ✅ CNPG component included for database initialization
- ✅ Health checks properly configured for postgres16

#### Service Naming:
- ✅ guacd service will be named `guacd.observability.svc.cluster.local` (correct in externalsecret)
- ✅ Guacamole app will be `guacamole.observability.svc.cluster.local`

#### Security:
- ✅ guacd runs as non-root (UID 1000) with hardened security context
- ⚠️ Guacamole app runs as root (required for Guacamole to function properly)
- ✅ All capabilities dropped where possible

#### Database Integration:
- ✅ CNPG component creates `guacamole-initdb-secret` automatically
- ✅ Init container `01-init-db` uses this secret to create DB user
- ✅ Schema migration init containers (02-04) use `guacamole-secret`
- ✅ Variable substitution `${APP}_postgres_password` will resolve correctly

#### OAuth/Authentik:
- ✅ OpenID endpoints configured for Authentik
- ✅ OPENID_REDIRECT_URI set to `https://rdp.${SECRET_DOMAIN}`
- ✅ TOTP_ENABLED for 2FA support

#### Networking:
- ✅ HTTPRoute configured for Envoy Gateway
- ✅ Gatus health check annotation present
- ✅ Subdomain: `rdp.${SECRET_DOMAIN}`

#### Images:
- ✅ All Guacamole images use same version (1.6.0) with SHA256 pinning
- ✅ postgres-init uses tag "18" (quoted correctly)

#### Persistence:
- ✅ emptyDir volumes appropriate for ephemeral data
- ✅ Migrations volume shared correctly between init containers
- 📋 Pre-deployment Checklist

#### Before deploying, ensure you have in aKeyless:
1. `/guacamole` key containing:
  - `GUACAMOLE_OAUTH_CLIENT_ID`
2, `/cnpg-users` key containing:
  - `guacamole_postgres_password`
3. Create Authentik OAuth provider with slug guacamole