### PR TITLE
chore(unifi-dns): test switching from k8s-gateway

### DIFF
--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ./echo/ks.yaml
   - ./envoy-gateway/ks.yaml
   - ./external-dns/ks.yaml
-  - ./k8s-gateway/ks.yaml
+  # - ./k8s-gateway/ks.yaml
   - ./proxy/ks.yaml
   - ./tailscale/ks.yaml
+  - ./unifi-dns/ks.yaml

--- a/kubernetes/apps/network/unifi-dns/app/externalsecret.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name unifi-dns-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless-secret-store
+  target:
+    name: *name
+    template:
+      data:
+        UNIFI_API_KEY: "{{ .UNIFI_DNS_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: /external-dns

--- a/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
@@ -1,0 +1,52 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app unifi-dns
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: unifi-dns
+  interval: 1h
+  values:
+    fullnameOverride: *app
+    provider:
+      name: webhook
+      webhook:
+        image:
+          repository: ghcr.io/kashalls/external-dns-unifi-webhook
+          tag: v0.7.0@sha256:a5503c1c61e3a8f6d66a0172fca6fb9affbe1f527ae6360ccf5ff5f0bf181c6e
+        env:
+          - name: UNIFI_HOST
+            value: https://unifi.internal
+          - name: UNIFI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: &secret unifi-dns-secret
+                key: UNIFI_API_KEY
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http-webhook
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: http-webhook
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+    triggerLoopOnEvent: true
+    policy: sync
+    sources:
+      - gateway-httproute
+      - service
+    txtOwnerId: main
+    txtPrefix: k8s.main.
+    domainFilters:
+      - "${SECRET_DOMAIN}"
+    serviceMonitor:
+      enabled: true
+    podAnnotations:
+      secret.reloader.stakater.com/reload: *secret

--- a/kubernetes/apps/network/unifi-dns/app/kustomization.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/network/unifi-dns/app/ocirepository.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: unifi-dns
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.19.0
+  url: oci://ghcr.io/home-operations/charts-mirror/external-dns

--- a/kubernetes/apps/network/unifi-dns/ks.yaml
+++ b/kubernetes/apps/network/unifi-dns/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: unifi-dns
+spec:
+  dependsOn:
+    - name: secret-stores
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/network/unifi-dns/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: network
+  wait: false


### PR DESCRIPTION
This automatically syncs DNS A records from your HTTPRoutes and Services to your UniFi controller (at https://192.168.1.1). When you create an HTTPRoute with a hostname like app.t0m.co, it will create a DNS record in UniFi pointing to the service's LoadBalancer IP.