### PR TITLE
fix(qol): add operator label & topologySpread

### DIFF
--- a/kubernetes/apps/database/cnpg/app/helmrelease.yaml
+++ b/kubernetes/apps/database/cnpg/app/helmrelease.yaml
@@ -10,6 +10,8 @@ spec:
     name: cnpg-operator
   interval: 1h
   values:
+    podLabels:
+      app.kubernetes.io/component: operator
     crds:
       create: true
     replicaCount: 2
@@ -17,3 +19,10 @@ spec:
       podMonitorEnabled: true
       grafanaDashboard:
         create: true
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: operator

--- a/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
+++ b/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
@@ -10,6 +10,8 @@ spec:
     name: dragonfly-operator
   interval: 1h
   values:
+    podLabels:
+      app.kubernetes.io/component: operator
     grafanaDashboard:
       enabled: true
     serviceMonitor:
@@ -23,6 +25,14 @@ spec:
       readOnlyRootFilesystem: true
       runAsNonRoot: true
       runAsUser: 1000
+    manager:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: operator
   # To resolve the targetDown prom alert when the dragonfly-operator chart
   # default ia set `--metrics-bind-address=127.0.0.1:8080`
   postRenderers:

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -10,7 +10,16 @@ spec:
     name: *app
   interval: 1h
   values:
+    podLabels:
+      app.kubernetes.io/component: operator
     dashboard:
       enabled: true
     serviceMonitor:
       enabled: true
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: operator


### PR DESCRIPTION
For a clean operator spreading without complexity, use `topologySpreadConstraints:` This approach:
- Spreads pods matching a label selector across nodes
- Works for any operator without per-operator configuration
- Uses standard Kubernetes labels operators already have