### PR TITLE
Revert "chore(container): update image ghcr.io/seerr-team/seerr ( a4f1a06 ➔ 0f6b5ff )"

### DIFF
--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/seerr-team/seerr
-              tag: develop@sha256:0f6b5ff28d52fcebe9aaf8ee3567a2d8c55d39d767b7667437362dadc3c7127b
+              tag: develop@sha256:a4f1a0614a5f4f1089472e495a6fa040cdd566d867c96a04427d12eb858a5485
             env:
               TZ: ${TIMEZONE:-UTC}
               LOG_LEVEL: 'info'


### PR DESCRIPTION
Reverts tscibilia/home-ops#1392

Seerr is failing to start due to a SQLite database constraint violation during the upgrade. The error indicates duplicate entries in the user_push_subscription table:
```
SQLITE_CONSTRAINT: UNIQUE constraint failed: user_push_subscription.endpoint, user_push_subscription.userId
```

https://github.com/seerr-team/seerr/commit/d0c9afc