### PR TITLE
Revert "feat(container): update image mirror.gcr.io/envoyproxy/gateway-helm ( v1.6.3 ➔ v1.7.0 )"

### DIFF
--- a/bootstrap/helmfile.d/00-crds.yaml
+++ b/bootstrap/helmfile.d/00-crds.yaml
@@ -16,7 +16,7 @@ releases:
   - name: envoy-gateway
     namespace: network
     chart: oci://mirror.gcr.io/envoyproxy/gateway-helm
-    version: v1.7.0
+    version: v1.6.3
 
   - name: grafana-operator
     namespace: observability

--- a/kubernetes/apps/network/envoy-gateway/app/ocirepository.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.7.0
+    tag: v1.6.3
   url: oci://mirror.gcr.io/envoyproxy/gateway-helm


### PR DESCRIPTION
Reverts tscibilia/home-ops#1607 due to upstream issue preventing ext-auth from redirecting