### PR TITLE
feat(cilium): migrate L2 announcements to BGP control plane

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -46,8 +46,10 @@ spec:
     k8sServicePort: 7445
     kubeProxyReplacement: true
     kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
-    l2announcements:
+    bgpControlPlane:
       enabled: true
+    l2announcements:
+      enabled: false
     loadBalancer:
       algorithm: maglev
       mode: "dsr"

--- a/kubernetes/apps/kube-system/cilium/app/networks.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networks.yaml
@@ -1,6 +1,6 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliumloadbalancerippool_v2alpha1.json
-apiVersion: cilium.io/v2alpha1
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliumloadbalancerippool_v2.json
+apiVersion: cilium.io/v2
 kind: CiliumLoadBalancerIPPool
 metadata:
   name: pool
@@ -9,15 +9,67 @@ spec:
   blocks:
     - cidr: "192.168.5.0/24"
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliuml2announcementpolicy_v2alpha1.json
-apiVersion: cilium.io/v2alpha1
-kind: CiliumL2AnnouncementPolicy
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliumbgpadvertisement_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumBGPAdvertisement
 metadata:
-  name: l2-policy
+  name: l3-bgp-advertisement
+  labels:
+    advertise: bgp
 spec:
-  loadBalancerIPs: true
-  interfaces:
-    - ^bond0$
+  advertisements:
+    - advertisementType: Service
+      service:
+        addresses:
+          - LoadBalancerIP
+      selector:
+        matchExpressions:
+          - {key: somekey, operator: NotIn, values: ["never-used-value"]}
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliumbgppeerconfig_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumBGPPeerConfig
+metadata:
+  name: l3-bgp-peer-config
+spec:
+  families:
+    - afi: ipv4
+      safi: unicast
+      advertisements:
+        matchLabels:
+          advertise: bgp
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliumbgpclusterconfig_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumBGPClusterConfig
+metadata:
+  name: l3-bgp-cluster-config
+spec:
   nodeSelector:
     matchLabels:
       node-role.kubernetes.io/control-plane: ""
+  bgpInstances:
+    - name: cilium
+      localASN: 64514
+      peers:
+        - name: unifi
+          peerASN: 64513
+          peerAddress: 192.168.5.1
+          peerConfigRef:
+            name: l3-bgp-peer-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-api
+  namespace: kube-system
+  annotations:
+    lbipam.cilium.io/ips: "192.168.5.250"
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  selector:
+    k8s-app: kube-apiserver
+    tier: control-plane
+  ports:
+    - port: 6443

--- a/kubernetes/bootstrap/helmfile.d/01-apps.yaml
+++ b/kubernetes/bootstrap/helmfile.d/01-apps.yaml
@@ -17,7 +17,7 @@ releases:
         command: bash
         args:
           - -c
-          - until kubectl get crd ciliumloadbalancerippools.cilium.io ciliuml2announcementpolicies.cilium.io &>/dev/null; do sleep 5; done
+          - until kubectl get crd ciliumloadbalancerippools.cilium.io ciliumbgpclusterconfigs.cilium.io ciliumbgppeerconfigs.cilium.io ciliumbgpadvertisements.cilium.io &>/dev/null; do sleep 5; done
         events:
           - postsync
         showlogs: true


### PR DESCRIPTION
  - Enable bgpControlPlane, disable l2announcements in helmrelease
  - Replace CiliumL2AnnouncementPolicy with BGP CRDs (v2 API)
  - Add CiliumBGPClusterConfig peering UDM-Pro at 192.168.5.1 (VLAN5 gateway)
  - Add kube-api LoadBalancer Service at 192.168.5.250
  - Update bootstrap helmfile CRD wait for BGP CRDs