### PR TITLE
feat(observability): add remote host metrics collection

### DIFF
--- a/.claude/context/03_networking.md
+++ b/.claude/context/03_networking.md
@@ -16,9 +16,17 @@
 
 Domain variable: `${SECRET_DOMAIN}` (from `cluster-secrets` Secret).
 
+## Known External Routes
+
+| Hostname | Path | Backend | File |
+|----------|------|---------|------|
+| `prometheus-rw.${SECRET_DOMAIN}` | `/api/v1/write` | `kube-prometheus-stack-prometheus:9090` | `observability/kube-prometheus-stack/app/httproute.yaml` |
+
+Protected by basic auth via `prometheus-web-config` secret (bcrypt, sourced from `/observability/remote` in aKeyless).
+
 ## HTTPRoute Pattern
 
-Routes are **inline in the HelmRelease** `values.route` block — no separate HTTPRoute manifest.
+Routes are **inline in the HelmRelease** `values.route` block — no separate HTTPRoute manifest. Exception: routes needing path-level auth (e.g., `prometheus-remote-write`) use a standalone `httproute-*.yaml` file.
 
 ```yaml
 # values section of HelmRelease

--- a/.claude/context/05_secrets.md
+++ b/.claude/context/05_secrets.md
@@ -51,4 +51,6 @@ spec:
 | `/database/cnpg-users` | CNPG user passwords (all apps share one secret, fields per-app) |
 | `/cloud-providers/b2-creds` | Backblaze B2 (VolSync bucket) |
 | `/network/tailscale/operator` | Tailscale operator credentials |
+| `/observability/gatus` | Alertmanager: healthchecks.io URL, Pushover tokens |
+| `/observability/remote` | Prometheus remote_write basic auth: `username`, `password`, `password_bcrypt` (bcrypt hash for web-config), `REMOTE_WRITE_URL` (full URL: `https://prometheus-rw.${SECRET_DOMAIN}/api/v1/write`) |
 

--- a/.claude/context/08_docker_hosts.md
+++ b/.claude/context/08_docker_hosts.md
@@ -17,6 +17,7 @@ Path: `docker/truenas/`
 |---|---------|-------------|
 | 01 | tailscale | `01-tailscale/docker-compose.yaml` |
 | 02 | scrutiny (collector) | `02-scrutiny/docker-compose.yaml` |
+| 03 | node-exporter, fluent-bit | `03-exporters/docker-compose.yaml` |
 
 NAS role: primary storage, NFS exports for media (`nfs-media` storage class).
 
@@ -44,6 +45,7 @@ Path: `docker/vps/`
 |---|---------|-------------|
 | 01 | pangolin | `01-pangolin/docker-compose.yaml` |
 | 02 | unifi | `02-unifi/docker-compose.yaml` |
+| 03 | node-exporter, fluent-bit, prometheus-agent | `03-observability/docker-compose.yaml` |
 
 VPS role: Pangolin ingress gateway (Cloudflare → VPS → Newt WireGuard tunnel → in-cluster `envoy-external`), UniFi controller. Ansible bootstrap owns `/opt/doco-cd/`; doco-cd owns the `01-pangolin/` and `02-unifi/` stacks via its own git clone of the repo.
 

--- a/docker/clonenas/03-exporters/docker-compose.yaml
+++ b/docker/clonenas/03-exporters/docker-compose.yaml
@@ -1,0 +1,119 @@
+---
+name: exporters
+services:
+  node-exporter:
+    image: quay.io/prometheus/node-exporter:v1.9.1
+    container_name: node-exporter
+    restart: unless-stopped
+    network_mode: host
+    pid: host
+    command:
+      - --path.rootfs=/host/root
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
+    volumes:
+      - /:/host/root:ro
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+
+  fluent-bit:
+    image: cr.fluentbit.io/fluent/fluent-bit:5.0
+    container_name: fluent-bit
+    restart: unless-stopped
+    network_mode: host
+    hostname: clonenas
+    command: ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/conf/fluent-bit.conf"]
+    volumes:
+      - /mnt/.ix-apps/docker/containers:/var/lib/docker/containers:ro
+      - fluent-bit-data:/fluent-bit/data
+    configs:
+      - source: fluent_bit_config
+        target: /fluent-bit/etc/conf/fluent-bit.conf
+      - source: fluent_bit_enrich
+        target: /fluent-bit/etc/conf/enrich.lua
+
+volumes:
+  fluent-bit-data:
+
+configs:
+  fluent_bit_config:
+    content: |
+      [SERVICE]
+          Daemon Off
+          Flush 5
+          Log_Level info
+          Parsers_File /fluent-bit/etc/parsers.conf
+
+      [INPUT]
+          Name tail
+          Path /var/lib/docker/containers/*/*-json.log
+          Parser docker
+          Tag docker
+          Path_Key filename
+          Refresh_Interval 5
+          Mem_Buf_Limit 10MB
+          Skip_Long_Lines On
+          DB /fluent-bit/data/docker.db
+
+      [FILTER]
+          Name lua
+          Match docker
+          Script /fluent-bit/etc/conf/enrich.lua
+          call enrich_container_name
+
+      [FILTER]
+          Name log_to_metrics
+          Match docker
+          Tag node_metrics
+          Metric_Name container_log_errors_total
+          Metric_Type counter
+          regex log (?i)error
+          Label_Field container
+          add_label host clonenas
+
+      [FILTER]
+          Name log_to_metrics
+          Match docker
+          Tag node_metrics
+          Metric_Name container_log_warnings_total
+          Metric_Type counter
+          regex log (?i)warn
+          Label_Field container
+          add_label host clonenas
+
+      [OUTPUT]
+          Name prometheus_exporter
+          Match node_metrics
+          Host 0.0.0.0
+          Port 2020
+
+      [OUTPUT]
+          Name null
+          Match docker
+
+  fluent_bit_enrich:
+    content: |
+      function enrich_container_name(tag, timestamp, record)
+          local filename = record["filename"]
+          if filename then
+              local container_id = filename:match("/containers/([^/]+)/")
+              if container_id then
+                  local config_path = "/var/lib/docker/containers/" .. container_id .. "/config.v2.json"
+                  local f = io.open(config_path, "r")
+                  if f then
+                      local content = f:read("*all")
+                      f:close()
+                      local name = content:match('"Name":"/?([^"]+)"')
+                      if name then
+                          record["container"] = name
+                      end
+                  end
+                  if not record["container"] then
+                      record["container"] = container_id
+                  end
+              end
+              record["filename"] = nil
+          end
+          return 1, timestamp, record
+      end

--- a/docker/truenas/03-exporters/docker-compose.yaml
+++ b/docker/truenas/03-exporters/docker-compose.yaml
@@ -1,0 +1,119 @@
+---
+name: exporters
+services:
+  node-exporter:
+    image: quay.io/prometheus/node-exporter:v1.9.1
+    container_name: node-exporter
+    restart: unless-stopped
+    network_mode: host
+    pid: host
+    command:
+      - --path.rootfs=/host/root
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
+    volumes:
+      - /:/host/root:ro
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+
+  fluent-bit:
+    image: cr.fluentbit.io/fluent/fluent-bit:5.0
+    container_name: fluent-bit
+    restart: unless-stopped
+    network_mode: host
+    hostname: truenas
+    command: ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/conf/fluent-bit.conf"]
+    volumes:
+      - /mnt/.ix-apps/docker/containers:/var/lib/docker/containers:ro
+      - fluent-bit-data:/fluent-bit/data
+    configs:
+      - source: fluent_bit_config
+        target: /fluent-bit/etc/conf/fluent-bit.conf
+      - source: fluent_bit_enrich
+        target: /fluent-bit/etc/conf/enrich.lua
+
+volumes:
+  fluent-bit-data:
+
+configs:
+  fluent_bit_config:
+    content: |
+      [SERVICE]
+          Daemon Off
+          Flush 5
+          Log_Level info
+          Parsers_File /fluent-bit/etc/parsers.conf
+
+      [INPUT]
+          Name tail
+          Path /var/lib/docker/containers/*/*-json.log
+          Parser docker
+          Tag docker
+          Path_Key filename
+          Refresh_Interval 5
+          Mem_Buf_Limit 10MB
+          Skip_Long_Lines On
+          DB /fluent-bit/data/docker.db
+
+      [FILTER]
+          Name lua
+          Match docker
+          Script /fluent-bit/etc/conf/enrich.lua
+          call enrich_container_name
+
+      [FILTER]
+          Name log_to_metrics
+          Match docker
+          Tag node_metrics
+          Metric_Name container_log_errors_total
+          Metric_Type counter
+          regex log (?i)error
+          Label_Field container
+          add_label host truenas
+
+      [FILTER]
+          Name log_to_metrics
+          Match docker
+          Tag node_metrics
+          Metric_Name container_log_warnings_total
+          Metric_Type counter
+          regex log (?i)warn
+          Label_Field container
+          add_label host truenas
+
+      [OUTPUT]
+          Name prometheus_exporter
+          Match node_metrics
+          Host 0.0.0.0
+          Port 2020
+
+      [OUTPUT]
+          Name null
+          Match docker
+
+  fluent_bit_enrich:
+    content: |
+      function enrich_container_name(tag, timestamp, record)
+          local filename = record["filename"]
+          if filename then
+              local container_id = filename:match("/containers/([^/]+)/")
+              if container_id then
+                  local config_path = "/var/lib/docker/containers/" .. container_id .. "/config.v2.json"
+                  local f = io.open(config_path, "r")
+                  if f then
+                      local content = f:read("*all")
+                      f:close()
+                      local name = content:match('"Name":"/?([^"]+)"')
+                      if name then
+                          record["container"] = name
+                      end
+                  end
+                  if not record["container"] then
+                      record["container"] = container_id
+                  end
+              end
+              record["filename"] = nil
+          end
+          return 1, timestamp, record
+      end

--- a/docker/vps/03-observability/docker-compose.yaml
+++ b/docker/vps/03-observability/docker-compose.yaml
@@ -1,0 +1,164 @@
+---
+name: observability
+services:
+  node-exporter:
+    image: quay.io/prometheus/node-exporter:v1.9.1
+    container_name: node-exporter
+    restart: unless-stopped
+    network_mode: host
+    pid: host
+    command:
+      - --path.rootfs=/host/root
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
+    volumes:
+      - /:/host/root:ro
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+
+  fluent-bit:
+    image: cr.fluentbit.io/fluent/fluent-bit:5.0
+    container_name: fluent-bit
+    restart: unless-stopped
+    network_mode: host
+    hostname: vps
+    command: ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/conf/fluent-bit.conf"]
+    volumes:
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - fluent-bit-data:/fluent-bit/data
+    configs:
+      - source: fluent_bit_config
+        target: /fluent-bit/etc/conf/fluent-bit.conf
+      - source: fluent_bit_enrich
+        target: /fluent-bit/etc/conf/enrich.lua
+
+  prometheus-agent:
+    image: quay.io/prometheus/prometheus:v3.4.0
+    container_name: prometheus-agent
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      - REMOTE_WRITE_USERNAME=${REMOTE_WRITE_USERNAME}
+      - REMOTE_WRITE_PASSWORD=${REMOTE_WRITE_PASSWORD}
+      - REMOTE_WRITE_URL=${REMOTE_WRITE_URL}
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --agent
+      - --storage.agent.path=/prometheus
+      - --config.expand-env=true
+    configs:
+      - source: prometheus_config
+        target: /etc/prometheus/prometheus.yml
+    volumes:
+      - prometheus-data:/prometheus
+
+volumes:
+  fluent-bit-data:
+  prometheus-data:
+
+configs:
+  prometheus_config:
+    content: |
+      global:
+        scrape_interval: 1m
+        scrape_timeout: 30s
+
+      scrape_configs:
+        - job_name: node-exporter
+          static_configs:
+            - targets: ['localhost:9100']
+              labels:
+                host: vps
+        - job_name: fluent-bit
+          static_configs:
+            - targets: ['localhost:2020']
+              labels:
+                host: vps
+
+      remote_write:
+        - url: ${REMOTE_WRITE_URL}
+          basic_auth:
+            username: ${REMOTE_WRITE_USERNAME}
+            password: ${REMOTE_WRITE_PASSWORD}
+
+  fluent_bit_config:
+    content: |
+      [SERVICE]
+          Daemon Off
+          Flush 5
+          Log_Level info
+          Parsers_File /fluent-bit/etc/parsers.conf
+
+      [INPUT]
+          Name tail
+          Path /var/lib/docker/containers/*/*-json.log
+          Parser docker
+          Tag docker
+          Path_Key filename
+          Refresh_Interval 5
+          Mem_Buf_Limit 10MB
+          Skip_Long_Lines On
+          DB /fluent-bit/data/docker.db
+
+      [FILTER]
+          Name lua
+          Match docker
+          Script /fluent-bit/etc/conf/enrich.lua
+          call enrich_container_name
+
+      [FILTER]
+          Name log_to_metrics
+          Match docker
+          Tag node_metrics
+          Metric_Name container_log_errors_total
+          Metric_Type counter
+          regex log (?i)error
+          Label_Field container
+          add_label host vps
+
+      [FILTER]
+          Name log_to_metrics
+          Match docker
+          Tag node_metrics
+          Metric_Name container_log_warnings_total
+          Metric_Type counter
+          regex log (?i)warn
+          Label_Field container
+          add_label host vps
+
+      [OUTPUT]
+          Name prometheus_exporter
+          Match node_metrics
+          Host 0.0.0.0
+          Port 2020
+
+      [OUTPUT]
+          Name null
+          Match docker
+
+  fluent_bit_enrich:
+    content: |
+      function enrich_container_name(tag, timestamp, record)
+          local filename = record["filename"]
+          if filename then
+              local container_id = filename:match("/containers/([^/]+)/")
+              if container_id then
+                  local config_path = "/var/lib/docker/containers/" .. container_id .. "/config.v2.json"
+                  local f = io.open(config_path, "r")
+                  if f then
+                      local content = f:read("*all")
+                      f:close()
+                      local name = content:match('"Name":"/?([^"]+)"')
+                      if name then
+                          record["container"] = name
+                      end
+                  end
+                  if not record["container"] then
+                      record["container"] = container_id
+                  end
+              end
+              record["filename"] = nil
+          end
+          return 1, timestamp, record
+      end

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/externalsecret.yaml
@@ -19,3 +19,24 @@ spec:
   dataFrom:
     - extract:
         key: /observability/gatus
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: prometheus-web-config
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless-secret-store
+  target:
+    name: prometheus-web-config
+    template:
+      data:
+        web-config.yaml: |
+          basic_auth_users:
+            {{ .username }}: {{ .password_bcrypt }}
+  dataFrom:
+    - extract:
+        key: /observability/remote

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -79,6 +79,13 @@ spec:
               resources:
                 requests:
                   storage: 50Gi
+        additionalArgs:
+          - name: web.enable-remote-write-receiver
+            value: ""
+          - name: web.config.file
+            value: /etc/prometheus/secrets/prometheus-web-config/web-config.yaml
+        secrets:
+          - prometheus-web-config
     prometheus-node-exporter:
       fullnameOverride: node-exporter
     kube-state-metrics:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/httproute.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: prometheus-remote-write
+spec:
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+  hostnames:
+    - prometheus-rw.${SECRET_DOMAIN}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/write
+      backendRefs:
+        - name: kube-prometheus-stack-prometheus
+          port: 9090

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
@@ -7,7 +7,9 @@ resources:
   - ./externalsecret.yaml
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./ocirepository.yaml
+  - ./scrapeconfigs
 configMapGenerator:
   - name: flux-metrics-configmap
     files:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfigs/fluent-bit.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfigs/fluent-bit.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: &name fluent-bit-remote
+spec:
+  staticConfigs:
+    - targets:
+        - truenas.internal:2020
+        - clonenas.internal:2020
+  metricsPath: /metrics
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: *name

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfigs/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfigs/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./node-exporter.yaml
+  - ./fluent-bit.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfigs/node-exporter.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfigs/node-exporter.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: &name node-exporter-remote
+spec:
+  staticConfigs:
+    - targets:
+        - truenas.internal:9100
+        - clonenas.internal:9100
+  metricsPath: /metrics
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: *name

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfigs/prometheusrule.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfigs/prometheusrule.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: remote-hosts-rules
+spec:
+  groups:
+    - name: remote-hosts.rules
+      rules:
+        - alert: DocoCdLogErrors
+          expr: rate(container_log_errors_total{container="doco-cd"}[5m]) > 0
+          for: 1m
+          labels:
+            severity: warning
+          annotations:
+            summary: "doco-cd errors on {{ $labels.instance }}"
+            description: "Error log lines detected in doco-cd. Check container logs on the affected host."


### PR DESCRIPTION
  - Add node-exporter + fluent-bit exporters to truenas, clonenas, vps
  - VPS uses prometheus-agent in agent mode with remote_write to cluster
  - Add ScrapeConfigs for truenas/clonenas (node-exporter:9100, fluent-bit:2020)
  - Add DocoCdLogErrors PrometheusRule (rate on container_log_errors_total)
  - Expose remote_write receiver on envoy-external with basic auth
  - Add prometheus-web-config ExternalSecret from aKeyless /observability/remote