### PR TITLE
chore(kopiur): naming identity

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -19,9 +19,6 @@ spec:
       name: kopiur-nas-secret
       namespace: kopiur-system
       key: KOPIA_PASSWORD
-  identityDefaults:
-    hostnameExpr: namespace
-    usernameExpr: namespace + '-' + policyName
   moverDefaults:
     cache:
       capacity: 1Mi

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -4,6 +4,8 @@ apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotPolicy
 metadata:
   name: ${APP}
+  annotations:
+    kopiur.home-operations.com/allow-identity-change: "true"
 spec:
   repository:
     kind: ClusterRepository


### PR DESCRIPTION
Simplify kopiur snapshot identities to **`<policyName>@<namespace>`** (was `<namespace>-<policyName>@<namespace>`) by dropping the `identityDefaults` block entirely — kopiur's built-in defaults are exactly `username` ← policy name, `hostname` ← namespace.

Identity is pinned at admission into each `SnapshotPolicy.status`, and kopiur's `identity_fork` webhook rejects any policy update whose resolved identity diverges from the pin. This PR therefore also adds the acknowledgement annotation to the backup component's SnapshotPolicy:

```yaml
kopiur.home-operations.com/allow-identity-change: "true"
```

Shipping both in one change matters: SSA applies are UPDATE requests even when no-op, so after the repo edit every Flux reconcile of the policies gets fork-checked — without the annotation, app Kustomizations would fail admission.

## Additional information

- Old history self-cleans, no data movement: existing `Snapshot` CRs carry their pinned identity in status and delete movers use it, so the old `<namespace>-<app>@<namespace>` snapshots prune normally as the windows slide — old identities empty out within ~7 days.
- Restores unaffected mid-transition (`fromPolicy` resolves through the CR catalog, not the identity string).
- No collision risk: hostname still carries the namespace, and policy names are unique within one.
- [ ] Follow-up (separate PR): once all policies show the re-pinned identity in status, drop the annotation so fork protection re-arms.
