### PR TITLE
chore(litellm): try moving llamacpp

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
   # - ./comfyui/ks.yaml
   - ./hermes/ks.yaml
   - ./litellm/ks.yaml
-  - ./llama-cpp/ks.yaml
+  # - ./llama-cpp/ks.yaml
   - ./llmkube/ks.yaml
   - ./memini/ks.yaml
   - ./open-webui/ks.yaml

--- a/kubernetes/apps/ai/litellm/app/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm/app/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - ./externalsecret.yaml
   - ./litellmproxy.yaml
   - ./litellmmodels.yaml
+  - ./llama-qwen.yaml
+  - ./llama-gemma.yaml
   - ./litellmmcpservers.yaml
   - ./mcp-secrets.yaml
   # - ./mcp-flux-rbac.yaml

--- a/kubernetes/apps/ai/litellm/app/litellmmodels.yaml
+++ b/kubernetes/apps/ai/litellm/app/litellmmodels.yaml
@@ -8,7 +8,36 @@ spec:
   modelName: *name
   params:
     model: openai/unsloth/Qwen3.6-27B
-    apiBase: http://llama-cpp.ai.svc.cluster.local:10000/v1
+    apiBase: http://llama-qwen.ai.svc.cluster.local:8080/v1
+    apiKeyRef:
+      name: litellm-secret
+      key: LLAMA_API_KEY
+    additional:
+      maxParallelRequests: 1
+    dropParams: true
+  info:
+    mode: chat
+    maxTokens: 32768
+    maxInputTokens: 262144
+    maxOutputTokens: 32768
+    supportsFunctionCalling: true
+    supportsVision: true
+    extra:
+      inputCostPerToken: 0.0000001250
+      cacheCreationInputTokenCost: 0.0000001250
+      cacheReadInputTokenCost: 0.0000000125
+      outputCostPerToken: 0.0000004999
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMModel
+metadata:
+  name: &name gemma-local
+spec:
+  modelName: *name
+  params:
+    model: openai/unsloth/gemma-4-26B-A4B
+    apiBase: http://llama-gemma.ai.svc.cluster.local:8080/v1
     apiKeyRef:
       name: litellm-secret
       key: LLAMA_API_KEY
@@ -137,3 +166,8 @@ spec:
     maxOutputTokens: 384000
     supportsFunctionCalling: true
     supportsPromptCaching: true
+    extra:
+      inputCostPerToken: 0.0000001250
+      cacheCreationInputTokenCost: 0.0000001250
+      cacheReadInputTokenCost: 0.0000000125
+      outputCostPerToken: 0.0000004999

--- a/kubernetes/apps/ai/litellm/app/llama-gemma.yaml
+++ b/kubernetes/apps/ai/litellm/app/llama-gemma.yaml
@@ -1,0 +1,83 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/model_v1alpha1.json
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: llama-gemma
+spec:
+  source: hf://unsloth/gemma-4-26B-A4B-it-GGUF
+  files:
+    - gemma-4-26B-A4B-it-UD-IQ4_NL.gguf
+  mmproj: mmproj-BF16.gguf
+  format: gguf
+  quantization: UD-IQ4_NL
+  hardware:
+    accelerator: cuda
+    gpu:
+      enabled: true
+      vendor: nvidia
+      layers: 99
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/inferenceservice_v1alpha1.json
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: llama-gemma
+spec:
+  modelRef: llama-gemma
+  runtime: llamacpp
+  image: ghcr.io/ggml-org/llama.cpp:server-cuda-b9982@sha256:7b3d7834fc7307cb54f24f8869b67bfff276404c416452a48d11321bc36a81be
+  replicas: 1
+  priority: normal
+  runtimeClassName: nvidia
+  nodeSelector:
+    feature.node.kubernetes.io/pci-10de.present: "true"
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+  contextSize: 131072
+  batchSize: 4096
+  uBatchSize: 2048
+  flashAttention: true
+  cacheTypeK: q8_0
+  cacheTypeV: q8_0
+  jinja: true
+  parallelSlots: 1
+  resources:
+    gpu: 1
+    cpu: 100m
+    memory: 20Gi
+  endpoint:
+    port: 8080
+    type: ClusterIP
+  extraArgs:
+    - --sleep-idle-seconds
+    - "3600"
+    - --alias
+    - unsloth/gemma-4-26B-A4B
+    - --temp
+    - "1.0"
+    - --top-k
+    - "64"
+    - --top-p
+    - "0.95"
+  probeOverrides:
+    startup:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 60
+    liveness:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 30
+      failureThreshold: 3
+    readiness:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 3

--- a/kubernetes/apps/ai/litellm/app/llama-qwen.yaml
+++ b/kubernetes/apps/ai/litellm/app/llama-qwen.yaml
@@ -1,0 +1,91 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/model_v1alpha1.json
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: llama-qwen
+spec:
+  source: hf://unsloth/Qwen3.6-27B-MTP-GGUF
+  files:
+    - Qwen3.6-27B-IQ4_NL.gguf
+  mmproj: mmproj-F16.gguf
+  format: gguf
+  quantization: IQ4_NL
+  hardware:
+    accelerator: cuda
+    gpu:
+      enabled: true
+      vendor: nvidia
+      layers: 99
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/inferenceservice_v1alpha1.json
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: llama-qwen
+spec:
+  modelRef: llama-qwen
+  runtime: llamacpp
+  image: ghcr.io/ggml-org/llama.cpp:server-cuda-b9982@sha256:7b3d7834fc7307cb54f24f8869b67bfff276404c416452a48d11321bc36a81be
+  replicas: 1
+  priority: high
+  runtimeClassName: nvidia
+  nodeSelector:
+    feature.node.kubernetes.io/pci-10de.present: "true"
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+  contextSize: 148480
+  batchSize: 2048
+  uBatchSize: 512
+  flashAttention: true
+  cacheTypeK: q4_0
+  cacheTypeV: q4_0
+  jinja: true
+  parallelSlots: 1
+  resources:
+    gpu: 1
+    cpu: 100m
+    memory: 20Gi
+  endpoint:
+    port: 8080
+    type: ClusterIP
+  extraArgs:
+    - --sleep-idle-seconds
+    - "3600"
+    - --alias
+    - unsloth/Qwen3.6-27B
+    - --temp
+    - "0.6"
+    - --top-k
+    - "20"
+    - --top-p
+    - "0.95"
+    - --min-p
+    - "0.0"
+    - --presence-penalty
+    - "0.0"
+    - --repeat-penalty
+    - "1.0"
+    - --chat-template-kwargs
+    - '{"enable_thinking":false}'
+  probeOverrides:
+    startup:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 60
+    liveness:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 30
+      failureThreshold: 3
+    readiness:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 3

--- a/kubernetes/apps/ai/llmkube/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/llmkube/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.9.5
+    tag: 0.9.6
   url: oci://ghcr.io/defilantech/charts/llmkube

--- a/kubernetes/apps/ai/open-webui/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/open-webui/app/externalsecret.yaml
@@ -12,6 +12,8 @@ spec:
     name: *name
     template:
       data:
+        LLAMA_API_KEY: "{{ .LLAMA_API_KEY }}"
+        LITELLM_MCP_API_KEY: "{{ .LITELLM_HOMELAB_KEY }}"
         OAUTH_CLIENT_ID: "{{ .OPENAI_OAUTH_CLIENT_ID }}"
         OAUTH_CLIENT_SECRET: "{{ .OPENAI_OAUTH_CLIENT_SECRET }}"
         WEBUI_SECRET_KEY: "{{ .OPENAI_WEBUI_SECRET_KEY }}"
@@ -19,5 +21,9 @@ spec:
   dataFrom:
     - extract:
         key: /ai/open-webui
+    - extract:
+        key: /ai/litellm
+    - extract:
+        key: /ai/llama-cpp
     - extract:
         key: /default/authentik

--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -24,14 +24,14 @@ spec:
               JWT_EXPIRES_IN: 604800
               CORS_ALLOW_ORIGIN: "https://${GATUS_SUBDOMAIN}.${SECRET_DOMAIN};http://localhost:8080"
               WEBUI_URL: "https://${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}"
-              OPENAI_API_BASE_URLS: "http://llama-cpp.ai.svc.cluster.local:10000/v1"
-              OPENAI_API_KEYS: "sk-no-key"
+              OPENAI_API_BASE_URLS: "http://litellm.ai.svc.cluster.local:4000/v1"
+              OPENAI_API_KEYS: "${LLAMA_API_KEY}"
               ENABLE_RAG_WEB_SEARCH: true
               RAG_WEB_SEARCH_ENGINE: "searxng"
               RAG_WEB_SEARCH_RESULT_COUNT: "5"
               SEARXNG_QUERY_URL: "http://searxng.default.svc.cluster.local:8080/search?q=<query>"
               USER_AGENT: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
-              TOOL_SERVER_CONNECTIONS: '[{"type":"mcp","url":"http://vmcp-mcp-gateway-int.ai.svc.cluster.local:4483/mcp","spec_type":"url","spec":"","path":"openapi.json","auth_type":"none","key":"","config":{"enable":true},"info":{"id":"mcp-gateway","name":"MCP Gateway","description":""}}]'
+              TOOL_SERVER_CONNECTIONS: '[{"type":"mcp","url":"http://litellm.ai.svc.cluster.local:4000/mcp","spec_type":"url","spec":"","path":"openapi.json","auth_type":"Bearer","key":"${LITELLM_MCP_API_KEY}","config":{"enable":true},"info":{"id":"mcp-gateway","name":"MCP Gateway","description":""}}]'
               USE_CUDA: false
               USE_OLLAMA: false
               ENABLE_SIGNUP: false

--- a/kubernetes/apps/default/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mealie/app/helmrelease.yaml
@@ -64,7 +64,7 @@ spec:
               OIDC_REMEMBER_ME: "true"
               OIDC_USER_CLAIM: email
               # OpenAI Values
-              OPENAI_BASE_URL: "http://llama-cpp.ai.svc.cluster.local:10000/v1"
+              OPENAI_BASE_URL: "http://litellm.ai.svc.cluster.local:4000/v1"
               OPENAI_API_KEY: "sk-no-key"
               OPENAI_MODEL: "unsloth/gemma-4-26B-A4B"
               OPENAI_ENABLE_IMAGE_SERVICES: "true" #creating recipes via image

--- a/kubernetes/apps/network/tailscale/configs/ts-ai3090-node.yaml
+++ b/kubernetes/apps/network/tailscale/configs/ts-ai3090-node.yaml
@@ -70,7 +70,7 @@ data:
         "$${TS_CERT_DOMAIN}:443": {
           "Handlers": {
             "/": {
-              "Proxy": "http://llama-cpp.ai.svc.cluster.local:10000"
+              "Proxy": "http://litellm.ai.svc.cluster.local:4000"
             }
           }
         }


### PR DESCRIPTION
## Migrate llama-cpp to llmkube InferenceServices, fix consumer URLs

### Summary

Replaces the hand-rolled `llama-cpp` app-template HelmRelease with two llmkube `Model` + `InferenceService` CRDs, matching the pattern already used by `memini-embed` / `memini-rerank`. Both models share the single RTX 3090 on ai3090 via priority-based GPU queue — qwen is `high`, gemma is `normal`. Idle models unload VRAM after 1 hour (`--sleep-idle-seconds 3600`).

### Changes

**New files — `kubernetes/apps/ai/litellm/app/`**

| File | Content |
|---|---|
| `llama-qwen.yaml` | Model (`hf://unsloth/Qwen3.6-27B-MTP-GGUF` + `mmproj-F16.gguf`) + InferenceService (CUDA, `priority: high`, qwen preset params) |
| `llama-gemma.yaml` | Model (`hf://unsloth/gemma-4-26B-A4B-it-GGUF` + `mmproj-BF16.gguf`) + InferenceService (CUDA, `priority: normal`, gemma preset params) |

Both use:
- `hf://` source with `files: []` + `mmproj:` for multi-file downloads
- `runtimeClassName: nvidia` + nodeSelector/tolerations for ai3090
- perService model cache (20Gi, `openebs-hostpath` = NVMe, no NAS)
- `--sleep-idle-seconds 3600` via extraArgs
- litellm auto-registers via the existing `llmkube.autoRegister: true` operator

**Modified files**

| File | Change |
|---|---|
| `litellm/app/kustomization.yaml` | +2 resources (llama-qwen.yaml, llama-gemma.yaml) |
| `litellm/app/litellmmodels.yaml` | Updated `qwen-local` apiBase → `llama-qwen:8080`; added `gemma-local` entry |
| `llmkube/app/ocirepository.yaml` | Bumped operator to `v0.9.6` |
| `ai/kustomization.yaml` | Commented out `llama-cpp/ks.yaml` |
| `open-webui/app/externalsecret.yaml` | Added `LITELLM_API_KEY` (from `/ai/litellm`) + `LITELLM_MCP_API_KEY` (from `/ai/llama-cpp`) |
| `open-webui/app/helmrelease.yaml` | Pointed `OPENAI_API_BASE_URLS` → `litellm:4000`, changed MCP `auth_type` to `Bearer`, split API/MCP keys |
| `mealie/app/helmrelease.yaml` | Pointed `OPENAI_BASE_URL` → `litellm:4000` |
| `tailscale/configs/ts-ai3090-node.yaml` | Pointed Tailscale proxy → `litellm:4000` |

### Removed references

- `llama-cpp` Kustomization is commented out (kept for rollback safety)
- All external consumers now route through `litellm.ai.svc.cluster.local:4000`

### Notes

- `hf://` works without tokens — both unsloth repos are public
- mmproj is supported directly in the Model CRD (`spec.mmproj`)
- No NAS or HDD needed — model cache uses the node-local NVMe (openebs-hostpath)
- GPU switching is manual via `kubectl scale inferenceservice` or priority queue preemption