### PR TITLE
chore(kube-system): add ocharted OCI proxy

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -92,8 +92,16 @@ jobs:
           RENOVATE_INTERNAL_CHECKS_FILTER: strict
           RENOVATE_PLATFORM: github
           RENOVATE_PLATFORM_COMMIT: true
+          RENOVATE_SECRETS: |-
+            {
+              "OCHARTED_USERNAME": "${{ secrets.OCHARTED_USERNAME }}",
+              "OCHARTED_PASSWORD": "${{ secrets.OCHARTED_PASSWORD }}"
+            }
           RENOVATE_HOST_RULES: |
-            [{"hostType": "docker", "matchHost": "ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GHCR_PAT }}"}]
+            [
+              {"hostType": "docker", "matchHost": "ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GHCR_PAT }}"},
+              {"hostType": "docker", "matchHost": "ocharted.${{ vars.SECRET_DOMAIN }}", "username": "{{ secrets.OCHARTED_USERNAME }}", "password": "{{ secrets.OCHARTED_PASSWORD }}"}
+            ]
         with:
           token: ${{ steps.app-token.outputs.token }}
           renovate-version: ${{ inputs.version || 'latest' }}

--- a/.mise.toml
+++ b/.mise.toml
@@ -37,6 +37,7 @@ TALOS_DIR = "{{config_root}}/kubernetes/talos"
 "github:home-operations/kopiur" = "0.9.1"
 "aqua:siderolabs/talos" = "1.13.7"
 "aqua:yannh/kubeconform" = "0.8.0"              # Kubernetes manifest validation
+actionlint = "1.7.12"
 
 [hooks]
 postinstall = "lefthook install"

--- a/kubernetes/apps/kube-system/descheduler/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 0.36.0
-  url: oci://ocharted.${SECRET_DOMAIN}/kubernetes-sigs.github.io/descheduler/descheduler
+  url: oci://ocharted.t0m.co/kubernetes-sigs.github.io/descheduler/descheduler

--- a/kubernetes/apps/kube-system/descheduler/ks.yaml
+++ b/kubernetes/apps/kube-system/descheduler/ks.yaml
@@ -8,10 +8,6 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/kube-system/descheduler/app
   prune: true
-  postBuild:
-    substituteFrom:
-      - kind: Secret
-        name: cluster-secrets
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - ./k8tz/ks.yaml
   - ./metrics-server/ks.yaml
   - ./nvidia-device-plugin/ks.yaml
+  - ./ocharted/ks.yaml
   - ./reloader/ks.yaml
   - ./snapshot-controller/ks.yaml
   - ./spegel/ks.yaml

--- a/kubernetes/apps/kube-system/ocharted/app/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/ocharted/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name ocharted-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless-secret-store
+  target:
+    name: *name
+    template:
+      data:
+        auth: "{{ .OCHARTED_USERNAME }}:{{ .OCHARTED_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: /kubernetes/ocharted

--- a/kubernetes/apps/kube-system/ocharted/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/ocharted/app/helmrelease.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app ocharted
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    replicaCount: 2
+    podDisruptionBudget:
+      enabled: true
+    auth:
+      existingSecret: ocharted-secret
+      bypassNetworks: [10.42.0.0/16]
+    deploymentAnnotations:
+      reloader.stakater.com/auto: "true"
+    httpRoute:
+      enabled: true
+      annotations:
+        gatus.home-operations.com/endpoint: |-
+          path: /healthz
+          conditions: ["[STATUS] == 200"]
+      hostnames: ["{{ .Release.Name }}.${SECRET_DOMAIN}"]
+      parentRefs:
+        - name: envoy-external
+          namespace: network
+    monitoring:
+      serviceMonitor:
+        enabled: true
+    resources:
+      requests:
+        cpu: 10m
+      limits:
+        memory: 512Mi

--- a/kubernetes/apps/kube-system/ocharted/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/ocharted/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/kube-system/ocharted/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/ocharted/app/ocirepository.yaml
@@ -3,12 +3,12 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: descheduler
+  name: ocharted
 spec:
   interval: 15m
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.36.0
-  url: oci://ocharted.${SECRET_DOMAIN}/kubernetes-sigs.github.io/descheduler/descheduler
+    tag: 0.1.3
+  url: oci://ghcr.io/home-operations/charts/ocharted

--- a/kubernetes/apps/kube-system/ocharted/ks.yaml
+++ b/kubernetes/apps/kube-system/ocharted/ks.yaml
@@ -3,15 +3,18 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app descheduler
+  name: &app ocharted
 spec:
+  dependsOn:
+    - name: secret-stores
+      namespace: external-secrets
   interval: 1h
-  path: ./kubernetes/apps/kube-system/descheduler/app
-  prune: true
+  path: ./kubernetes/apps/kube-system/ocharted/app
   postBuild:
     substituteFrom:
       - kind: Secret
         name: cluster-secrets
+  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
## Summary

Deploys [ocharted](https://github.com/home-operations/ocharted) 0.1.3 in `kube-system` — a stateless OCI registry proxy that serves classic HTTP Helm repositories as OCI artifacts, exposed at `ocharted.${SECRET_DOMAIN}` with basic auth.

### Deployment (`kubernetes/apps/kube-system/ocharted`)
- OCIRepository + HelmRelease via `chartRef`
- Basic auth (`OCHARTED_USERNAME`/`OCHARTED_PASSWORD`) from Akeyless via ExternalSecret, wired through `auth.existingSecret` with `reloader.stakater.com/auto` to roll pods on credential rotation
- `auth.bypassNetworks: [10.42.0.0/16]` (pod CIDR): in-cluster Flux pulls anonymously through the public hostname, external clients must authenticate
- Chart-managed HTTPRoute on `envoy-external` with gatus probe against `/healthz`
- ServiceMonitor enabled; 512Mi memory limit

### Renovate
- `hostRules` for `ocharted.${SECRET_DOMAIN}` via `RENOVATE_HOST_RULES` env var in the workflow (not local renovate overrides.yaml, referencing credentials from `RENOVATE_SECRETS`
- Chart picked up by the existing Flux manager preset

### Requires before merge
- Akeyless path `/kubernetes/ocharted` with `OCHARTED_USERNAME` and `OCHARTED_PASSWORD` fields
- GitHub Actions variable `SECRET_DOMAIN` (Settings → Secrets and variables → Actions → Variables)

### charts-mirror migration
One OCIRepository migrated from the static `ghcr.io/home-operations/charts-mirror` artifact to ocharted:
