### PR TITLE
fix(pocket-id): repair MaxMind secret extraction blocking pocket-id reconcile

### DIFF
--- a/kubernetes/apps/security/pocket-id/instance/externalsecret.yaml
+++ b/kubernetes/apps/security/pocket-id/instance/externalsecret.yaml
@@ -14,13 +14,12 @@ spec:
       data:
         ENCRYPTION_KEY: "{{ .POCKETID_ENCRYPTION_KEY }}"
         MAXMIND_LICENSE_KEY: "{{ .MAXMIND_PANGOLIN_LICENSE_KEY }}"
-        DB_CONNECTION_STRING: |-
-          postgres://{{ .${APP} }}:{{ .${APP}_postgres_password }}@${CNPG_NAME:=pgsql-cluster}-rw.database.svc.cluster.local/{{ .${APP} }}
-
+  data:
+    - secretKey: MAXMIND_PANGOLIN_LICENSE_KEY
+      remoteRef:
+        key: /docker/vps-maxmind/license-key
   dataFrom:
     - extract:
         key: /database/cnpg-users
-    - extract:
-        key: /docker/vps-maxmind/license-key
     - extract:
         key: /security/pocket-id


### PR DESCRIPTION
## Summary
- \`pocket-id-secret\` ExternalSecret was failing to sync entirely
  (\`unable to unmarshal secret from JSON\`), which blocked \`pocketid\`'s
  pod, the \`pocket-id\` Kustomization, and everything depending on it
  (\`tinyauth\`, \`actual\`)
- Root cause: \`dataFrom.extract\` against a plain-text (non-JSON) aKeyless
  secret shared with VPS crowdsec
- Fix: \`data[].remoteRef\` instead, matching existing repo precedent
- Also removes an unused, likely-broken \`DB_CONNECTION_STRING\` field

## Test plan
- [x] \`flate build all\` clean, 0 new failures
- [ ] \`pocket-id-secret\` ExternalSecret syncs after merge
- [ ] \`pocketid\` pod reaches Running
- [ ] \`pocket-id\`/\`tinyauth\`/\`actual\` Kustomizations go Ready