### PR TITLE
fix(pocket-id): correct instanceSelector label after pocketid rename

### DIFF
--- a/kubernetes/apps/default/actual/app/pocketidoidcclient.yaml
+++ b/kubernetes/apps/default/actual/app/pocketidoidcclient.yaml
@@ -10,7 +10,7 @@ spec:
   pkceEnabled: true
   instanceSelector:
     matchLabels:
-      app.kubernetes.io/name: pocket-id
+      app.kubernetes.io/name: pocketid
   secret:
     enabled: true
     name: actual-oidc-secret

--- a/kubernetes/apps/security/tinyauth/app/pocketidoidcclient.yaml
+++ b/kubernetes/apps/security/tinyauth/app/pocketidoidcclient.yaml
@@ -10,7 +10,7 @@ spec:
   pkceEnabled: true
   instanceSelector:
     matchLabels:
-      app.kubernetes.io/name: pocket-id
+      app.kubernetes.io/name: pocketid
   secret:
     enabled: true
     name: tinyauth-oidc-secret


### PR DESCRIPTION
## Summary
- \`tinyauth\` and \`actual\` pods stuck in \`CreateContainerConfigError\`
  (\`secret "tinyauth-oidc-secret" not found\` / same for actual)
- Root cause, confirmed via pocket-id-operator logs: their
  \`PocketIDOIDCClient.instanceSelector\` still targeted
  \`app.kubernetes.io/name: pocket-id\`, but the instance was renamed to
  \`pocketid\` in #3225's fold-in — the operator derives that label from
  the instance's own name, so the selector matched nothing
- Fix: update both selectors to \`pocketid\`

## Test plan
- [x] \`flate build all\` clean, 0 new failures, both clients render
      \`app.kubernetes.io/name: pocketid\`
- [ ] Both \`PocketIDOIDCClient\` resources go Ready with a client secret
- [ ] \`tinyauth\` and \`actual\` pods reach Running