### PR TITLE
fix(pocket-id): drop broken instanceSelector on tinyauth/actual clients

### DIFF
--- a/kubernetes/apps/default/actual/app/pocketidoidcclient.yaml
+++ b/kubernetes/apps/default/actual/app/pocketidoidcclient.yaml
@@ -8,9 +8,12 @@ spec:
   callbackUrls:
     - "https://${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}/openid/callback"
   pkceEnabled: true
-  instanceSelector:
-    matchLabels:
-      app.kubernetes.io/name: pocketid
+  # No instanceSelector: the PocketIDInstance carries no app.kubernetes.io/name
+  # label (verified live — only Flux's kustomize.toolkit.fluxcd.io/* labels are
+  # present), so any matchLabels selector here matches nothing and the client
+  # never gets a secret. There is exactly one PocketIDInstance in this cluster;
+  # the operator's default-instance fallback (proven working via pangolin's
+  # client) is what actually resolves this.
   secret:
     enabled: true
     name: actual-oidc-secret

--- a/kubernetes/apps/security/tinyauth/app/pocketidoidcclient.yaml
+++ b/kubernetes/apps/security/tinyauth/app/pocketidoidcclient.yaml
@@ -8,9 +8,12 @@ spec:
   callbackUrls:
     - "https://tinyauth.${SECRET_DOMAIN}/api/oauth/callback/pocketid"
   pkceEnabled: true
-  instanceSelector:
-    matchLabels:
-      app.kubernetes.io/name: pocketid
+  # No instanceSelector: the PocketIDInstance carries no app.kubernetes.io/name
+  # label (verified live — only Flux's kustomize.toolkit.fluxcd.io/* labels are
+  # present), so any matchLabels selector here matches nothing and the client
+  # never gets a secret. There is exactly one PocketIDInstance in this cluster;
+  # the operator's default-instance fallback (proven working via pangolin's
+  # client) is what actually resolves this.
   secret:
     enabled: true
     name: tinyauth-oidc-secret


### PR DESCRIPTION
## Summary
- Follow-up to #3227, which fixed the wrong thing: it corrected the
  selector's label *value* but the PocketIDInstance has no
  \`app.kubernetes.io/name\` label at all (confirmed via full \`metadata\`
  dump — only \`kustomize.toolkit.fluxcd.io/*\` labels present)
- Any \`instanceSelector.matchLabels\` here was always going to match
  nothing, so \`tinyauth\` and \`actual\` never got an OIDC secret
- pangolin's client has no \`instanceSelector\` and has reconciled fine
  since creation — proof the operator's single-instance default works
- Fix: drop the selector from both clients, with a comment explaining why

## Test plan
- [x] \`flate build all\` clean, 0 new failures
- [ ] Both \`PocketIDOIDCClient\` resources go Ready with a client secret
- [ ] \`tinyauth\` and \`actual\` pods reach Running