### PR TITLE
docs(context): correct renovate inline comment guidance

### DIFF
--- a/.agents/context/07_flux_conventions.md
+++ b/.agents/context/07_flux_conventions.md
@@ -5,7 +5,7 @@
 - **dependsOn uses Kustomization names:** `dependsOn` references the Kustomization resource name (defined in `ks.yaml`), NOT the HelmRelease name — these are different objects.
 - **kubectl edit is ephemeral:** Any `kubectl edit` change is overwritten by the next Flux reconciliation. All changes must go through git.
 - **apply-ks touches the live cluster:** `just kube apply-ks` runs server-side apply against the live cluster API without pushing to git — it is not a dry run; do not run it speculatively.
-- **No renovate inline comments:** Never add `# renovate:` inline comments to YAML. This repo does not use them.
+- **Renovate inline comments:** Only add `# renovate:` where no manager auto-detects the version — flux/helm-values/kubernetes managers already scan all `.yaml`/`.yml`/`.j2` files. Reserve it for custom CRD fields, e.g. `newt.tag` in `pangolin-operator/config/newtsite.yaml`.
 
 ## Local Rendering
 


### PR DESCRIPTION
The blanket "never use # renovate: comments" claim was wrong on both counts: ~13 files in the repo already use them, and they're needed for custom CRD fields (e.g. newt.tag) that no renovate manager auto-detects.