### PR TITLE
feat(towonel-agent): and default external-dns records to DNS-only

### DIFF
--- a/kubernetes/apps/default/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/default/immich/app/helmrelease.yaml
@@ -134,10 +134,6 @@ spec:
 
     route:
       app:
-        annotations:
-          # DNS-only: Cloudflare's proxy caps request bodies at 100MB, which fails
-          # large photo/video uploads with NSURLErrorDomain -1017 on the iOS client.
-          external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
         hostnames: ["${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}"]
         parentRefs:
           - name: envoy-external

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -89,9 +89,6 @@ spec:
     route:
       app:
         annotations:
-          # DNS-only: proxying video streams through Cloudflare caps request bodies at
-          # 100MB and is disallowed for non-Enterprise plans. Pangolin/Traefik is the edge.
-          external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
           gatus.home-operations.com/endpoint: |-
             url: https://{{ .Release.Name }}.${SECRET_DOMAIN}/${GATUS_PATH}
         hostnames: ["{{ .Release.Name }}.${SECRET_DOMAIN}"]

--- a/kubernetes/apps/network/external-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/app/helmrelease.yaml
@@ -20,7 +20,6 @@ spec:
             key: *name
     extraArgs:
       - --cloudflare-dns-records-per-page=1000
-      - --cloudflare-proxied
       - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
       - --crd-source-kind=DNSEndpoint
       - --gateway-name=envoy-external

--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -16,4 +16,5 @@ resources:
   - ./multus/ks.yaml
   - ./pangolin-operator/ks.yaml
   - ./tailscale/ks.yaml
+  - ./towonel-agent/ks.yaml
   - ./unifi-dns/ks.yaml

--- a/kubernetes/apps/network/pangolin-operator/config/dnsendpoint.yaml
+++ b/kubernetes/apps/network/pangolin-operator/config/dnsendpoint.yaml
@@ -12,11 +12,6 @@ spec:
       recordTTL: 60
       targets:
         - ${VPS_IP}
-      # DNS-only: Cloudflare's proxy caps request bodies at 100MB, which breaks
-      # large Immich uploads. Pangolin/Traefik is the intended edge for this record.
-      providerSpecific:
-        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
-          value: "false"
     - dnsName: external.${CEAPP_DOMAIN}
       recordType: A
       recordTTL: 60

--- a/kubernetes/apps/network/towonel-agent/app/externalsecret.yaml
+++ b/kubernetes/apps/network/towonel-agent/app/externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name towonel-agent-secret
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless-secret-store
+  target:
+    name: *name
+    creationPolicy: Owner
+    template:
+      data:
+        TOWONEL_INVITE_TOKEN: "{{ .invite_token }}"
+        TOWONEL_VPS_IP: "{{ .towonel_vps_ip }}"
+  data:
+    - secretKey: invite_token
+      remoteRef:
+        key: /network/towonel-agent
+        property: invite_token
+    - secretKey: towonel_vps_ip
+      remoteRef:
+        key: docker/vps-towonel/ip

--- a/kubernetes/apps/network/towonel-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/network/towonel-agent/app/helmrelease.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app towonel-agent
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    agent:
+      services:
+        - hostname: "*.${SECRET_DOMAIN}"
+          origin: &origin envoy-external.network.svc.cluster.local:443
+        - hostname: "*.${CEAPP_DOMAIN}"
+          origin: *origin
+        - hostname: "${CEAPP_DOMAIN}"
+          origin: *origin
+      inviteTokenSecret:
+        name: towonel-agent-secret
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+    serviceMonitor:
+      main:
+        enabled: true

--- a/kubernetes/apps/network/towonel-agent/app/kustomization.yaml
+++ b/kubernetes/apps/network/towonel-agent/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/network/towonel-agent/app/ocirepository.yaml
+++ b/kubernetes/apps/network/towonel-agent/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: towonel-agent
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.5.2
+  url: oci://codeberg.org/towonel/charts/towonel-agent

--- a/kubernetes/apps/network/towonel-agent/config/dnsendpoint.yaml
+++ b/kubernetes/apps/network/towonel-agent/config/dnsendpoint.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/externaldns.k8s.io/dnsendpoint_v1alpha1.json
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: towonel-agent
+spec:
+  endpoints:
+    - dnsName: twnl-external.${SECRET_DOMAIN}
+      recordType: A
+      recordTTL: 60
+      targets: &target
+        - ${TOWONEL_VPS_IP}
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
+    - dnsName: twnl-external.${CEAPP_DOMAIN}
+      recordType: A
+      recordTTL: 60
+      targets: *target
+    - dnsName: twnl.${SECRET_DOMAIN}
+      recordType: A
+      recordTTL: 60
+      targets: *target

--- a/kubernetes/apps/network/towonel-agent/config/dnsendpoint.yaml
+++ b/kubernetes/apps/network/towonel-agent/config/dnsendpoint.yaml
@@ -11,9 +11,6 @@ spec:
       recordTTL: 60
       targets: &target
         - ${TOWONEL_VPS_IP}
-      providerSpecific:
-        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
-          value: "false"
     - dnsName: twnl-external.${CEAPP_DOMAIN}
       recordType: A
       recordTTL: 60
@@ -22,9 +19,3 @@ spec:
       recordType: A
       recordTTL: 60
       targets: *target
-      # DNS-only: Caddy on the VPS obtains its cert for this hostname via
-      # ACME tls-alpn-01, which needs the challenge to reach Caddy directly.
-      # Proxying would terminate TLS at Cloudflare's edge and break issuance.
-      providerSpecific:
-        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
-          value: "false"

--- a/kubernetes/apps/network/towonel-agent/config/dnsendpoint.yaml
+++ b/kubernetes/apps/network/towonel-agent/config/dnsendpoint.yaml
@@ -22,3 +22,9 @@ spec:
       recordType: A
       recordTTL: 60
       targets: *target
+      # DNS-only: Caddy on the VPS obtains its cert for this hostname via
+      # ACME tls-alpn-01, which needs the challenge to reach Caddy directly.
+      # Proxying would terminate TLS at Cloudflare's edge and break issuance.
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"

--- a/kubernetes/apps/network/towonel-agent/config/kustomization.yaml
+++ b/kubernetes/apps/network/towonel-agent/config/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./dnsendpoint.yaml

--- a/kubernetes/apps/network/towonel-agent/ks.yaml
+++ b/kubernetes/apps/network/towonel-agent/ks.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app towonel-agent
+spec:
+  dependsOn:
+    - name: secret-stores
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/network/towonel-agent/app
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: network
+  wait: true
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: towonel-agent-config
+spec:
+  dependsOn:
+    - name: towonel-agent
+  interval: 1h
+  path: ./kubernetes/apps/network/towonel-agent/config
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+      - kind: Secret
+        name: towonel-agent-secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: network
+  wait: true


### PR DESCRIPTION
## Summary

Task 4 of the towonel migration: deploys the in-cluster `towonel-agent`
alongside `pangolin-operator`, and inverts the external-dns Cloudflare
proxy default.

**No traffic moves.** All 25 apps continue to serve through Pangolin. The
agent is deployed and connected but nothing routes to it yet — the canary
cutover is a later PR.

Design: `.agents/superpowers/specs/2026-08-06-towonel-migration-design.md`

## What's here

**`towonel-agent` (new)** — the origin-side connector. Holds a QUIC tunnel to
the hub on the temporary VPS and forwards TLS-passthrough traffic to
`envoy-external:443`. Split into two Flux Kustomizations mirroring
`pangolin-operator`: `app/` creates the ExternalSecret, `config/` publishes
DNS records using a `TOWONEL_VPS_IP` substitution that only exists once that
secret has synced.

Chart and image are both pinned to `1.5.2`. The chart pins its agent image by
digest, so the HelmRelease deliberately does **not** override it — chart and
image must move together or the tunnel wire format can drift against the hub.

**DNS records published** (none affect current routing):
- `twnl-external.${SECRET_DOMAIN}` / `twnl-external.${CEAPP_DOMAIN}` — canary
  targets for the next PR
- `twnl.${SECRET_DOMAIN}` — hub control plane, and what lets Caddy on the VPS
  finally complete ACME

**external-dns default flipped to DNS-only** — dropped the global
`--cloudflare-proxied` flag. That default had already been worked around three
separate times (`external.${SECRET_DOMAIN}`, `plex`, `immich`), each with its
own comment explaining the 100MB proxy body cap. Those overrides are now
redundant and removed; behaviour for those three is unchanged.

## Why the DNS change belongs with this one

A Cloudflare-proxied hostname terminates TLS at Cloudflare's edge. towonel's
entire premise is that the tunnel operator cannot read your traffic, so
proxying contradicts it.

More concretely: `twnl.${SECRET_DOMAIN}` needs ACME `tls-alpn-01`, and proxied,
the challenge never reaches Caddy — the certificate can never issue. The hub is
sitting in that exact backoff right now.

## Behaviour change to be aware of

~20 app hostnames and both `cetranscript` records were riding the proxied
default with no explicit override. They become DNS-only: answering with the
origin IP, losing Cloudflare DDoS absorption, WAF and caching, and gaining true
end-to-end TLS passthrough with no body cap.

If any hostname should stay proxied, it needs an explicit opt-in:

```yaml
providerSpecific:
  - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
    value: "true"

Validation

- flate test all → 365 passed
- Hub verified healthy at the temporary VPS: {"status":"ok","version":"1.5.2"}
- Invite issued and stored in aKeyless at /network/towonel-agent

After merge

Watch in order: external-dns creates twnl.${SECRET_DOMAIN} → Caddy obtains
its certificate (docker restart caddy-l4 skips the ACME backoff) → the agent
connects.

Then check the agent logs do not contain no edge advertised an iroh address. That warning means no tunnel exists regardless of pods reporting
Ready — the main silent failure mode in this migration.
```