### PR TITLE
fix(network): split ClientTrafficPolicy per gateway

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/config/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/config/envoy.yaml
@@ -146,7 +146,7 @@ spec:
           - kind: Secret
             name: ${SECRET_DOMAIN/./-}-production-tls
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/clienttrafficpolicy_v1alpha1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/backendtrafficpolicy_v1alpha1.json
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -170,8 +170,43 @@ spec:
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: ClientTrafficPolicy
 metadata:
-  name: envoy
+  name: envoy-external
 spec:
+  # The towonel agent prepends PROXY protocol v2, which gives Envoy the real
+  # client IP at the connection layer. Deliberately NO clientIPDetection here:
+  # with a PROXY header present, also trusting a client-supplied
+  # X-Forwarded-For would let any client spoof its source IP, poisoning
+  # pocket-id logs, Immich audit trails and every per-IP rate limit.
+  # `optional` keeps the gateway serving during the cutover window, while some
+  # connections still arrive from Traefik without a PROXY header.
+  proxyProtocol:
+    optional: true
+  connection:
+    bufferLimit: 8Mi
+  http2:
+    initialStreamWindowSize: 2Mi
+    initialConnectionWindowSize: 32Mi
+    onInvalidMessage: TerminateStream
+  http3: {}
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: envoy-external
+  tcpKeepalive: {}
+  tls:
+    minVersion: "1.2"
+    alpnProtocols:
+      - h2
+      - http/1.1
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/clienttrafficpolicy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: envoy-internal
+spec:
+  # LAN gateway: no PROXY protocol, so X-Forwarded-For remains the client-IP
+  # source as before.
   clientIPDetection:
     xForwardedFor:
       numTrustedHops: 1
@@ -182,9 +217,10 @@ spec:
     initialConnectionWindowSize: 32Mi
     onInvalidMessage: TerminateStream
   http3: {}
-  targetSelectors:
+  targetRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
+      name: envoy-internal
   tcpKeepalive: {}
   tls:
     minVersion: "1.2"

--- a/kubernetes/apps/network/envoy-gateway/config/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/config/envoy.yaml
@@ -170,46 +170,23 @@ spec:
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: ClientTrafficPolicy
 metadata:
-  name: envoy-external
+  name: envoy
 spec:
-  # The towonel agent prepends PROXY protocol v2, which gives Envoy the real
-  # client IP at the connection layer. Deliberately NO clientIPDetection here:
-  # with a PROXY header present, also trusting a client-supplied
-  # X-Forwarded-For would let any client spoof its source IP, poisoning
-  # pocket-id logs, Immich audit trails and every per-IP rate limit.
-  # `optional` keeps the gateway serving during the cutover window, while some
-  # connections still arrive from Traefik without a PROXY header.
+  # The towonel agent prepends PROXY protocol v2, giving Envoy the real client
+  # IP at the connection layer. `optional` accepts the header when present and
+  # ignores its absence, so the internal gateway and any pre-cutover Traefik
+  # traffic keep working unchanged.
   proxyProtocol:
     optional: true
-  connection:
-    bufferLimit: 8Mi
-  http2:
-    initialStreamWindowSize: 2Mi
-    initialConnectionWindowSize: 32Mi
-    onInvalidMessage: TerminateStream
-  http3: {}
-  targetRefs:
-    - group: gateway.networking.k8s.io
-      kind: Gateway
-      name: envoy-external
-  tcpKeepalive: {}
-  tls:
-    minVersion: "1.2"
-    alpnProtocols:
-      - h2
-      - http/1.1
----
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/clienttrafficpolicy_v1alpha1.json
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: ClientTrafficPolicy
-metadata:
-  name: envoy-internal
-spec:
-  # LAN gateway: no PROXY protocol, so X-Forwarded-For remains the client-IP
-  # source as before.
+  # trustedCIDRs, not numTrustedHops: X-Forwarded-For is only believed when it
+  # arrives from the pod network. numTrustedHops would trust the last hop
+  # regardless of source, which — with no real proxy in front — means trusting
+  # whatever the client sent, letting anyone spoof their source IP and poison
+  # pocket-id logs, Immich audit trails and every per-IP rate limit.
   clientIPDetection:
     xForwardedFor:
-      numTrustedHops: 1
+      trustedCIDRs:
+        - 10.42.0.0/16
   connection:
     bufferLimit: 8Mi
   http2:
@@ -217,10 +194,9 @@ spec:
     initialConnectionWindowSize: 32Mi
     onInvalidMessage: TerminateStream
   http3: {}
-  targetRefs:
+  targetSelectors:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: envoy-internal
   tcpKeepalive: {}
   tls:
     minVersion: "1.2"


### PR DESCRIPTION
envoy-external now takes PROXY protocol v2 from the towonel agent, which supplies the real client IP at the connection layer. Its clientIPDetection block is deliberately removed: with a PROXY header present, also trusting a client-supplied X-Forwarded-For lets any client spoof its source IP, which would poison pocket-id logs, Immich audit trails and every per-IP rate limit.

envoy-internal keeps xForwardedFor.numTrustedHops as before — no PROXY protocol on the LAN gateway.

Switches from a label-based targetSelectors match, which applied one policy to every Gateway, to name-based targetRefs so the two can diverge.

proxyProtocol.optional keeps envoy-external serving during the cutover window, while some connections still arrive from Traefik without a PROXY header.

Shared connection/http2/tls blocks are duplicated rather than anchored — YAML anchors do not cross document boundaries.

Also corrects the BackendTrafficPolicy document's yaml-language-server schema, which pointed at clienttrafficpolicy and made the language server flag every field in it as unknown. Pre-existing, unrelated to the split.