### PR TITLE
feat/towonel-observability-canary

### DIFF
--- a/docker/towonel/.doco-cd.yaml
+++ b/docker/towonel/.doco-cd.yaml
@@ -34,6 +34,18 @@ external_secrets:
     store_ref: akeyless
     remote_ref:
       key: docker/vps-towonel/acme-email
+  DOMAIN:
+    store_ref: akeyless
+    remote_ref:
+      key: docker/secret-domain
+  PROMETHEUS_USERNAME:
+    store_ref: akeyless
+    remote_ref:
+      key: docker/vps-prometheus/username
+  PROMETHEUS_PASSWORD:
+    store_ref: akeyless
+    remote_ref:
+      key: docker/vps-prometheus/password
 force_recreate: false
 reconciliation:
   enabled: true

--- a/docker/towonel/01-towonel/docker-compose.yaml
+++ b/docker/towonel/01-towonel/docker-compose.yaml
@@ -35,6 +35,12 @@ services:
       - "8443"
     ports:
       - 51820:51820/udp
+      # Metrics on loopback only, for the host-networked prometheus-agent in
+      # 03-exporters. Not reachable off-box: ufw denies both ports, and the
+      # 127.0.0.1 bind means Docker never opens them to the outside anyway.
+      # 9091 = hub metrics, 9092 = edge metrics (one process, two endpoints).
+      - 127.0.0.1:9091:9091
+      - 127.0.0.1:9092:9092
     volumes:
       - /opt/towonel:/data
     healthcheck:

--- a/docker/towonel/03-exporters/docker-compose.yaml
+++ b/docker/towonel/03-exporters/docker-compose.yaml
@@ -1,0 +1,71 @@
+---
+name: exporters
+services:
+  node-exporter:
+    image: quay.io/prometheus/node-exporter:v1.12.1
+    container_name: node-exporter
+    restart: unless-stopped
+    network_mode: host
+    pid: host
+    command:
+      - --path.rootfs=/host/root
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
+      - --no-collector.edac
+    volumes:
+      - /:/host/root:ro
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+
+  prometheus-agent:
+    image: quay.io/prometheus/prometheus:v3.13.2
+    container_name: prometheus-agent
+    restart: unless-stopped
+    network_mode: host
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --agent
+      - --storage.agent.path=/prometheus
+    configs:
+      - source: prometheus_config
+        target: /etc/prometheus/prometheus.yml
+    volumes:
+      - prometheus-data:/prometheus
+
+volumes:
+  prometheus-data:
+
+configs:
+  prometheus_config:
+    content: |
+      global:
+        scrape_interval: 1m
+        scrape_timeout: 30s
+
+      scrape_configs:
+        # Job names are load-bearing: the upstream towonel-hub Grafana dashboard
+        # selects on job=~"towonel-(hub|edge).*". Renaming these empties every
+        # panel. The hub and edge are one process; they export on separate
+        # ports, published on loopback by the 01-towonel stack.
+        - job_name: towonel-hub
+          static_configs:
+            - targets: ['127.0.0.1:9091']
+              labels:
+                host: towonel
+        - job_name: towonel-edge
+          static_configs:
+            - targets: ['127.0.0.1:9092']
+              labels:
+                host: towonel
+        - job_name: node-exporter
+          static_configs:
+            - targets: ['127.0.0.1:9100']
+              labels:
+                host: towonel
+
+      remote_write:
+        - url: https://prometheus-rw.${DOMAIN}/api/v1/write
+          basic_auth:
+            username: ${PROMETHEUS_USERNAME}
+            password: ${PROMETHEUS_PASSWORD}

--- a/kubernetes/apps/network/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/network/echo/app/helmrelease.yaml
@@ -17,6 +17,11 @@ spec:
     httpRoute:
       enabled: true
       annotations:
+        # CANARY for the towonel migration: this route alone resolves to the
+        # towonel edge instead of the gateway's default Pangolin target. Every
+        # other app keeps using external.${SECRET_DOMAIN}. Removing this line
+        # reverts echo to Pangolin in one DNS TTL (60s).
+        external-dns.alpha.kubernetes.io/target: twnl-external.${SECRET_DOMAIN}
         gatus.home-operations.com/endpoint: |-
           conditions: ["[STATUS] == 200"]
       hostnames: ["{{ .Release.Name }}.${SECRET_DOMAIN}"]


### PR DESCRIPTION
## Hub/Edge exporter
Publishes the hub (9091) and edge (9092) metrics ports on 127.0.0.1 so the
host-networked agent can scrape them. Both already bind 0.0.0.0 inside the
container; the loopback bind keeps them off the public interface, and ufw
denies both regardless.

Job names are towonel-hub and towonel-edge because the upstream dashboard
selects on job=~"towonel-(hub|edge).*" — renaming them empties every panel.


## Canary test - Echo pod
`echo` is now doubly useful as the canary, since it reports client IP and headers directly.
Just swaps the `external-dns` target