### PR TITLE
feat(network): cut over external ingress to towonel

### DIFF
--- a/kubernetes/apps/network/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/network/echo/app/helmrelease.yaml
@@ -17,11 +17,6 @@ spec:
     httpRoute:
       enabled: true
       annotations:
-        # CANARY for the towonel migration: this route alone resolves to the
-        # towonel edge instead of the gateway's default Pangolin target. Every
-        # other app keeps using external.${SECRET_DOMAIN}. Removing this line
-        # reverts echo to Pangolin in one DNS TTL (60s).
-        external-dns.alpha.kubernetes.io/target: twnl-external.${SECRET_DOMAIN}
         gatus.home-operations.com/endpoint: |-
           conditions: ["[STATUS] == 200"]
       hostnames: ["{{ .Release.Name }}.${SECRET_DOMAIN}"]

--- a/kubernetes/apps/network/pangolin-operator/config/dnsendpoint.yaml
+++ b/kubernetes/apps/network/pangolin-operator/config/dnsendpoint.yaml
@@ -7,16 +7,6 @@ metadata:
   namespace: network
 spec:
   endpoints:
-    - dnsName: external.${SECRET_DOMAIN}
-      recordType: A
-      recordTTL: 60
-      targets:
-        - ${VPS_IP}
-    - dnsName: external.${CEAPP_DOMAIN}
-      recordType: A
-      recordTTL: 60
-      targets:
-        - ${VPS_IP}
     - dnsName: ${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}
       recordType: A
       recordTTL: 60

--- a/kubernetes/apps/network/towonel-agent/config/dnsendpoint.yaml
+++ b/kubernetes/apps/network/towonel-agent/config/dnsendpoint.yaml
@@ -19,3 +19,13 @@ spec:
       recordType: A
       recordTTL: 60
       targets: *target
+    - dnsName: external.${SECRET_DOMAIN}
+      recordType: A
+      recordTTL: 60
+      targets: *target
+      # DNS-only (global default): Cloudflare's proxy caps request bodies at
+      # 100MB, which breaks large Immich uploads.
+    - dnsName: external.${CEAPP_DOMAIN}
+      recordType: A
+      recordTTL: 60
+      targets: *target


### PR DESCRIPTION
Moves external.* record ownership from pangolin to towonel-agent in a single commit — external-dns runs policy:sync, so a gap in ownership would delete the records. All 25 apps move together. Pangolin stays running; rollback is reverting this commit (60s TTL).