### PR TITLE
fix(ansible): escalate with su, not sudo, on the VPS

### DIFF
--- a/ansible/mod.just
+++ b/ansible/mod.just
@@ -17,13 +17,14 @@ install-collections:
     just check-tools ansible-galaxy
     ansible-galaxy collection install -r "{{ ansible_dir }}/requirements.yaml"
 
-[doc('Bootstrap VPS (subsequent runs — ubuntu user, port 22222)')]
+[doc('Bootstrap VPS (subsequent runs — ubuntu user, port 22222; prompts for root password)')]
 [script]
 bootstrap-vps *args:
     just check-tools ansible-playbook
     ansible-playbook -i {{ ansible_dir }}/inventory/hosts.yaml {{ ansible_dir }}/vps/playbook.yaml \
         --limit vps \
         --private-key ~/.ssh/home-ops \
+        --ask-become-pass \
         {{ args }}
 
 [doc('Bootstrap VPS first run (root user, port 22)')]

--- a/ansible/vps/playbook.yaml
+++ b/ansible/vps/playbook.yaml
@@ -2,6 +2,10 @@
 - name: Bootstrap towonel VPS
   hosts: all
   gather_facts: false
+  # The ubuntu account is passwordless by design and there is no NOPASSWD
+  # drop-in, so sudo cannot escalate. root has a password, so su can.
+  # Every run needs -K, and the prompt wants root's password, not ubuntu's.
+  become_method: ansible.builtin.su
   vars:
     ansible_user: ubuntu
     ansible_python_interpreter: auto_silent


### PR DESCRIPTION
The ubuntu account is passwordless by design and carries no NOPASSWD
drop-in, so sudo cannot escalate. root has a password, so su can.
Adds --ask-become-pass to the bootstrap-vps recipe; the prompt wants
root's password.
