### PR TITLE
revert(ansible): drop the VPS hostname task

### DIFF
--- a/ansible/vps/playbook.yaml
+++ b/ansible/vps/playbook.yaml
@@ -17,12 +17,6 @@
     - name: Check host connectivity
       ansible.builtin.ping:
 
-    - name: Set hostname
-      become: true
-      tags: hostname
-      ansible.builtin.hostname:
-        name: "{{ inventory_hostname_short }}"
-
     - name: Read secrets from aKeyless
       ansible.builtin.shell: "akeyless get-secret-value --name '{{ item }}'"
       delegate_to: localhost


### PR DESCRIPTION
Renaming the host to a name /etc/hosts does not carry makes su and
sudo warn 'unable to resolve host' on every call. Keeping the
SolusVM-generated name is the smaller change.
