### PR TITLE
feat(vps): add crowdsec with a host firewall bouncer

### DIFF
--- a/.agents/context/08_docker_hosts.md
+++ b/.agents/context/08_docker_hosts.md
@@ -45,6 +45,7 @@ Path: `docker/vps/`
 | --- | ------------------------------------------- | -------------------------------------- |
 | 01  | caddy-l4                                    | `01-caddy-l4/docker-compose.yaml`      |
 | 02  | towonel                                     | `02-towonel/docker-compose.yaml`       |
+| 03  | crowdsec (engine; host bouncer via Ansible) | `03-crowdsec/docker-compose.yaml`      |
 | 04  | unifi                                       | `04-unifi/docker-compose.yaml`         |
 | 05  | node-exporter, fluent-bit, prometheus-agent | `05-observability/docker-compose.yaml` |
 | 06  | unifi-backup (restic→B2), ofelia scheduler  | `06-unfbkup/docker-compose.yaml`       |

--- a/ansible/mod.just
+++ b/ansible/mod.just
@@ -109,6 +109,25 @@ restart-doco-cd host:
         ;;
     esac
 
+[doc('List active CrowdSec bans on the VPS')]
+[script]
+bans:
+    just check-tools ssh
+    ssh -i ~/.ssh/home-ops -p 22222 ubuntu@vps.internal \
+        "docker exec crowdsec cscli decisions list"
+
+[doc('Unban an IP from CrowdSec on the VPS')]
+[script]
+unban ip:
+    just check-tools ssh
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ssh -i ~/.ssh/home-ops -p 22222 ubuntu@vps.internal \
+        "docker exec crowdsec cscli decisions delete --ip '{{ ip }}'"
+    echo "Remaining decisions:"
+    ssh -i ~/.ssh/home-ops -p 22222 ubuntu@vps.internal \
+        "docker exec crowdsec cscli decisions list"
+
 [doc('Emergency: SCP compose file directly to VPS and restart service (bypasses doco-cd/git)')]
 [script]
 deploy-direct service:

--- a/ansible/vps/playbook.yaml
+++ b/ansible/vps/playbook.yaml
@@ -327,6 +327,97 @@
             user: root
             state: present
 
+    - name: crowdsec
+      become: true
+      tags: crowdsec
+      block:
+        - name: crowdsec | Read bouncer key from aKeyless
+          ansible.builtin.shell: "akeyless get-secret-value --name 'docker/vps-crowdsec/bouncer-api-key'"
+          delegate_to: localhost
+          become: false
+          check_mode: false
+          changed_when: false
+          no_log: true
+          register: crowdsec_secret_raw
+
+        - name: crowdsec | Set bouncer key fact
+          ansible.builtin.set_fact:
+            crowdsec_bouncer_api_key: "{{ crowdsec_secret_raw.stdout }}"
+          no_log: true
+
+        - name: crowdsec | Create data directories
+          ansible.builtin.file:
+            path: "{{ item }}"
+            state: directory
+            owner: root
+            group: root
+            mode: "0755"
+          loop:
+            - /opt/crowdsec/config
+            - /opt/crowdsec/data
+
+        - name: crowdsec | Create apt keyring directory
+          ansible.builtin.file:
+            path: /etc/apt/keyrings
+            state: directory
+            owner: root
+            group: root
+            mode: "0755"
+
+        - name: crowdsec | Add apt signing key
+          ansible.builtin.get_url:
+            url: https://packagecloud.io/crowdsec/crowdsec/gpgkey
+            dest: /etc/apt/keyrings/crowdsec.asc
+            owner: root
+            group: root
+            mode: "0644"
+
+        - name: crowdsec | Add apt repository
+          ansible.builtin.apt_repository:
+            repo: "deb [signed-by=/etc/apt/keyrings/crowdsec.asc] https://packagecloud.io/crowdsec/crowdsec/any any main"
+            filename: crowdsec
+            state: present
+            update_cache: true
+
+        # Only the bouncer is a host package. The engine runs as a container
+        # in 03-crowdsec; the bouncer must be on the host to write iptables.
+        - name: crowdsec | Install host firewall bouncer
+          ansible.builtin.apt:
+            name: crowdsec-firewall-bouncer-iptables
+            state: present
+
+        - name: crowdsec | Render bouncer config
+          ansible.builtin.template:
+            src: crowdsec-firewall-bouncer.yaml.j2
+            dest: /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+            owner: root
+            group: root
+            mode: "0600"
+          no_log: true
+          notify: Restart crowdsec-firewall-bouncer
+
+        # doco-cd deploys the engine on its own poll cycle, so on a first
+        # bootstrap the container may not exist yet. Registration is skipped
+        # rather than failed; re-run this tag once the stack is up.
+        - name: crowdsec | Check the engine container is running
+          ansible.builtin.command: docker ps --filter name=^crowdsec$ --format '{{ '{{' }}.Names{{ '}}' }}'
+          register: crowdsec_engine
+          changed_when: false
+          failed_when: false
+
+        - name: crowdsec | Register firewall bouncer (idempotent)
+          ansible.builtin.shell: |
+            set -e
+            if docker exec crowdsec cscli bouncers list -o json | grep -q '"name":"firewall"'; then
+              echo "ALREADY_REGISTERED"
+            else
+              docker exec crowdsec cscli bouncers add firewall --key "{{ crowdsec_bouncer_api_key }}"
+            fi
+          register: crowdsec_bouncer_reg
+          changed_when: "'ALREADY_REGISTERED' not in crowdsec_bouncer_reg.stdout"
+          no_log: true
+          when: "'crowdsec' in crowdsec_engine.stdout"
+
     # Needs `-e unifi_host=true`.
     - name: unfbkup
       when: unifi_host | default(false) | bool
@@ -385,4 +476,9 @@
     - name: Restart ssh.socket
       ansible.builtin.service:
         name: ssh.socket
+        state: restarted
+
+    - name: Restart crowdsec-firewall-bouncer
+      ansible.builtin.service:
+        name: crowdsec-firewall-bouncer
         state: restarted

--- a/ansible/vps/templates/crowdsec-firewall-bouncer.yaml.j2
+++ b/ansible/vps/templates/crowdsec-firewall-bouncer.yaml.j2
@@ -1,0 +1,18 @@
+---
+# Managed by ansible/vps/playbook.yaml -- do not edit on the host.
+mode: iptables
+update_frequency: 10s
+log_mode: file
+log_dir: /var/log/
+log_level: info
+api_url: http://127.0.0.1:8088/
+api_key: {{ crowdsec_bouncer_api_key }}
+insecure_skip_verify: false
+disable_ipv6: false
+deny_action: DROP
+deny_log: false
+# Ordered before the DOCKER chain so bans apply to published container ports,
+# which bypass ufw's INPUT chain entirely.
+iptables_chains:
+  - INPUT
+  - DOCKER-USER

--- a/docker/vps/.doco-cd.yaml
+++ b/docker/vps/.doco-cd.yaml
@@ -82,6 +82,14 @@ external_secrets:
     store_ref: akeyless
     remote_ref:
       key: docker/vps-towonel/acme-email
+  CROWDSEC_ENROLL_KEY:
+    store_ref: akeyless
+    remote_ref:
+      key: docker/vps-crowdsec/enroll-key
+  HOME_IP_CIDR:
+    store_ref: akeyless
+    remote_ref:
+      key: docker/vps-crowdsec/home-ip-cidr
 force_recreate: false
 reconciliation:
   enabled: true

--- a/docker/vps/03-crowdsec/config/acquis.d/vps.yaml
+++ b/docker/vps/03-crowdsec/config/acquis.d/vps.yaml
@@ -1,0 +1,21 @@
+---
+# sshd on 22222. rsyslog is active on this host, so auth.log is the simplest
+# source; no journald plumbing needed inside the container.
+source: file
+filenames:
+  - /var/log/auth.log
+labels:
+  type: syslog
+---
+# caddy-l4 logs JSON to stdout under the json-file driver, so the docker
+# datasource reads it straight from the socket.
+#
+# SCOPE: caddy only terminates TLS for the UniFi vhost. Everything else on
+# :443 is SNI-routed to the towonel edge without decryption, so no HTTP for
+# tunnelled apps ever reaches these logs. The ban-ai-crawlers scenario keys
+# off http_user_agent and therefore only ever sees UniFi traffic.
+source: docker
+container_name:
+  - caddy-l4
+labels:
+  type: caddy

--- a/docker/vps/03-crowdsec/config/scenarios/ban-ai-crawlers.yaml
+++ b/docker/vps/03-crowdsec/config/scenarios/ban-ai-crawlers.yaml
@@ -1,0 +1,13 @@
+---
+type: trigger
+name: custom/ban-ai-crawlers
+description: "Ban AI crawlers and scrapers by user-agent"
+filter: >-
+  evt.Parsed.http_user_agent != nil
+  && evt.Parsed.http_user_agent matches
+  "(?i)(Meta-ExternalAgent|meta-webindexer|GPTBot|CCBot|Google-Extended|Bytespider|Amazonbot|Applebot-Extended)"
+groupby: evt.Meta.source_ip
+blackhole: 5m
+labels:
+  remediation: true
+  type: ban

--- a/docker/vps/03-crowdsec/config/scenarios/ban-asn.yaml
+++ b/docker/vps/03-crowdsec/config/scenarios/ban-asn.yaml
@@ -1,0 +1,13 @@
+---
+type: trigger
+name: custom/ban-asn
+description: "Ban traffic from AS numbers"
+filter: >-
+  evt.Meta.ASNumber in [
+    "32934"
+  ]
+groupby: evt.Meta.source_ip
+blackhole: 5m
+labels:
+  remediation: true
+  type: ban

--- a/docker/vps/03-crowdsec/docker-compose.yaml
+++ b/docker/vps/03-crowdsec/docker-compose.yaml
@@ -1,0 +1,69 @@
+---
+name: crowdsec
+services:
+  crowdsec:
+    image: ghcr.io/crowdsecurity/crowdsec:v1.7.8@sha256:2f527c9bb8b367120eb08b82890aa912ce96bfa1ada93dda0721700e4b4e0dde
+    container_name: crowdsec
+    restart: unless-stopped
+    environment:
+      COLLECTIONS: crowdsecurity/linux crowdsecurity/sshd crowdsecurity/caddy
+      # whitelists backs the home allowlist below; geoip-enrich populates
+      # evt.Meta.ASNumber, without which the ban-asn scenario never matches.
+      PARSERS: crowdsecurity/whitelists crowdsecurity/geoip-enrich
+      ENROLL_KEY: ${CROWDSEC_ENROLL_KEY}
+      ENROLL_INSTANCE_NAME: vps-crowdsec
+      ENROLL_TAGS: vps towonel
+      GID: "1000"
+    ports:
+      # LAPI for the host firewall bouncer, and Prometheus metrics. Both bound
+      # to loopback: published container ports bypass ufw entirely, so binding
+      # 0.0.0.0 would expose them publicly no matter what the firewall says.
+      # Host port 8088 because UniFi already holds 8080.
+      - 127.0.0.1:8088:8080
+      - 127.0.0.1:6060:6060
+    volumes:
+      - /opt/crowdsec/config:/etc/crowdsec
+      - /opt/crowdsec/data:/var/lib/crowdsec/data
+      - /var/log/auth.log:/var/log/auth.log:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    configs:
+      - source: acquis
+        target: /etc/crowdsec/acquis.d/vps.yaml
+      - source: allowlist
+        target: /etc/crowdsec/parsers/s02-enrich/my-allowlists.yaml
+      - source: ban_asn
+        target: /etc/crowdsec/scenarios/ban-asn.yaml
+      - source: ban_ai_crawlers
+        target: /etc/crowdsec/scenarios/ban-ai-crawlers.yaml
+    healthcheck:
+      test: ["CMD", "cscli", "lapi", "status"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+configs:
+  acquis:
+    file: ./config/acquis.d/vps.yaml
+  ban_asn:
+    file: ./config/scenarios/ban-asn.yaml
+  ban_ai_crawlers:
+    file: ./config/scenarios/ban-ai-crawlers.yaml
+  # Inline rather than a file because only `content` interpolates variables,
+  # and HOME_IP_CIDR comes from aKeyless. Editing this block does NOT recreate
+  # the container on its own — force-recreate after any change.
+  #
+  # HOME_IP_CIDR is a flow-style YAML list body, so it holds any number of
+  # ranges and a new one needs only an aKeyless edit, no repo change
+  allowlist:
+    content: |
+      name: custom/home-allowlist
+      description: "Allow home ISP ranges"
+      whitelist:
+        reason: "Home ISP"
+        cidr: [${HOME_IP_CIDR}]
+
+networks:
+  default:
+    name: edge
+    external: true

--- a/docker/vps/README.md
+++ b/docker/vps/README.md
@@ -54,13 +54,13 @@ the network it replaced, `edge` is provisioned by Ansible
 survives any stack being removed.
 
 Directories are numbered by dependency order — `caddy-l4` owns `:443` and must
-come up first, and `towonel` is the tunnel it feeds. `03` is reserved for
-`crowdsec`.
+come up first, `towonel` is the tunnel it feeds, and `crowdsec` watches both.
 
 | #   | Directory           | Services                                    | Data path       |
 | --- | ------------------- | ------------------------------------------- | --------------- |
 | 01  | `01-caddy-l4/`      | caddy-l4 (SNI splitter, UniFi vhost)        | —               |
 | 02  | `02-towonel/`       | towonel-node (hub + edge)                   | `/opt/towonel/` |
+| 03  | `03-crowdsec/`      | crowdsec engine (LAPI on 127.0.0.1:8088)    | —               |
 | 04  | `04-unifi/`         | unifi-network-application, unifi-db (mongo) | `/opt/unifi/`   |
 | 05  | `05-observability/` | node-exporter, fluent-bit, prometheus-agent | —               |
 | 06  | `06-unfbkup/`       | restic (UniFi → B2), ofelia (scheduler)     | —               |
@@ -115,6 +115,8 @@ mapping. Key paths:
 | Prometheus remote-write  | `docker/vps-prometheus/username`, `.../password`             |
 | UniFi Mongo credentials  | `docker/vps-unifi/mongo-*`                                   |
 | UniFi restic/B2 backup   | `docker/vps-unifi/restic-*`, `docker/vps-unifi/b2-*`         |
+| CrowdSec bouncer key     | `docker/vps-crowdsec/bouncer-api-key`                        |
+| CrowdSec console enrol   | `docker/vps-crowdsec/enroll-key`                             |
 
 ## SSH access
 


### PR DESCRIPTION
Containerised engine in 03-crowdsec reading sshd via auth.log and
caddy-l4 via the docker datasource, with the firewall bouncer installed
on the host by Ansible so bans reach published container ports through
DOCKER-USER.

Carries over the home allowlist and the ban-asn and ban-ai-crawlers
scenarios from the retired pangolin stack. The allowlist now takes a
list of CIDRs so a changed home range is an aKeyless edit. LAPI and
metrics bind loopback only — the previous stack published 6060 on all
interfaces, which ufw does not filter.
