### PR TITLE
feat(docs): publish the docs as a docsify site on GitHub Pages

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,0 +1,35 @@
+- [Map — glossary & routing](/CONTEXT.md)
+
+- **Cluster Context**
+    - [Apps Inventory](/docs/context/apps.md)
+    - [Kustomize Components](/docs/context/components.md)
+    - [Docker Hosts](/docs/context/docker-hosts.md)
+    - [Networking](/docs/context/networking.md)
+    - [Cluster Nodes](/docs/context/nodes.md)
+    - [Secrets](/docs/context/secrets.md)
+    - [Storage](/docs/context/storage.md)
+    - [Teardown & Replacement](/docs/context/teardown.md)
+
+- **Cluster ADRs**
+    - [Follow onedr0p's cluster-template and his home-ops patterns](/docs/adr/0001-follow-onedr0p-cluster-template.md)
+    - [Flux repository conventions](/docs/adr/0002-flux-repository-conventions.md)
+    - [External Secrets Operator with aKeyless, replacing SOPS](/docs/adr/0003-external-secrets-akeyless-over-sops.md)
+    - [CloudNativePG for PostgreSQL](/docs/adr/0004-cloudnativepg-for-postgresql.md)
+    - [VolSync for PVC backup](/docs/adr/0005-volsync-for-pvc-backup.md)
+    - [Authentik for SSO](/docs/adr/0006-authentik-for-sso.md)
+    - [KEDA for scale-to-zero](/docs/adr/0007-keda-for-scale-to-zero.md)
+    - [Envoy Gateway over ingress-nginx](/docs/adr/0008-envoy-gateway-over-ingress-nginx.md)
+    - [Pangolin for external ingress](/docs/adr/0009-pangolin-for-external-ingress.md)
+    - [zeroscaler (native HPA + prometheus-adapter) over KEDA](/docs/adr/0010-zeroscaler-over-keda.md)
+    - [Separate pgvector cluster for vector workloads](/docs/adr/0011-pgvector-cluster-split.md)
+    - [konflate (flate) over flux-local for local rendering](/docs/adr/0012-konflate-over-flux-local.md)
+    - [kopiur over VolSync for PVC backup](/docs/adr/0013-kopiur-over-volsync.md)
+    - [pocket-id and tinyauth over Authentik](/docs/adr/0014-pocket-id-tinyauth-over-authentik.md)
+    - [towonel over Pangolin for public ingress](/docs/adr/0015-towonel-over-pangolin.md)
+
+- **For agents**
+    - [Domain Docs](/docs/agents/domain.md)
+    - [Issue tracker: GitHub](/docs/agents/issue-tracker.md)
+    - [Triage Labels](/docs/agents/triage-labels.md)
+
+- [Worklog](/docs/WORKLOG.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,8 @@ Three rules, and they're the whole contract:
 
 **Some sections are generated.** Anything between `<!-- BEGIN GENERATED: … -->` markers is written by [`scripts/generate.py`](scripts/generate.py) from the repo itself — don't hand-edit inside them. Hand-written prose _inside_ a generated block is preserved across regeneration, keyed by row.
 
+The same script writes `_sidebar.md` at the repo root — the navigation for the [published docs site](https://tscibilia.github.io/home-ops/), labelled from each file's H1. That one is generated whole, so anything typed into it is lost on the next run. Adding an ADR or a context file puts it in the nav automatically; nothing lists the pages by hand.
+
 ```sh
 just docs generate   # rewrite the generated sections
 just docs test       # gate: sections in sync, and every identifier named in the docs still resolves

--- a/docs/mod.just
+++ b/docs/mod.just
@@ -10,13 +10,13 @@ scripts_dir := justfile_dir() + '/docs/scripts'
 default:
     just -l docs
 
-[doc('Render the generated sections of docs/context/ from the repo')]
+[doc('Render the generated docs from the repo — docs/context/ sections and _sidebar.md')]
 [script]
 generate:
     just check-tools python3
     python3 "{{ scripts_dir }}/generate.py"
 
-[doc('Validate docs/context/ against the repo — generated sections and named identifiers')]
+[doc('Validate the docs against the repo — generated output and named identifiers')]
 [no-exit-message]
 [script]
 test:

--- a/docs/scripts/generate.py
+++ b/docs/scripts/generate.py
@@ -1,16 +1,19 @@
 #!/usr/bin/env python3
-"""Render the generated sections of docs/context/ from the repo itself.
+"""Render the generated documentation from the repo itself.
 
-Each block is delimited by BEGIN/END markers. Prose outside the markers is never
-touched, and hand-written text *inside* a block is preserved across runs, keyed
-by the row it belongs to — so the enumeration stays true to disk while the
-editorial voice stays human.
+Two kinds of output:
 
-That hand-written text lives nowhere else, so wiping a block would destroy it.
-Before writing, each block is compared against the last committed version: if a
-row that still exists on disk has lost its prose, the run stops unless --force.
+Blocks, spliced into docs/context/ between BEGIN/END markers. Prose outside the
+markers is never touched, and hand-written text *inside* a block is preserved
+across runs, keyed by the row it belongs to — so the enumeration stays true to
+disk while the editorial voice stays human. That text lives nowhere else, so
+wiping a block would destroy it: before writing, each block is compared against
+the last committed version, and if a row that still exists on disk has lost its
+prose the run stops unless --force. Add one by appending to BLOCKS.
 
-Add a block by appending to BLOCKS. Everything else is shared.
+Whole files, rewritten outright. _sidebar.md is the docsify navigation and has
+no hand-written content at all — every label is read from a file's H1 — so
+there is nothing to preserve and no guard around it.
 """
 
 from __future__ import annotations
@@ -138,6 +141,45 @@ def stacks_render(host: str):
 
 
 # --------------------------------------------------------------------------
+# sidebar — _sidebar.md, the docsify navigation
+# --------------------------------------------------------------------------
+
+SIDEBAR = ROOT / "_sidebar.md"
+SIDEBAR_SECTIONS = [
+    ("Cluster Context", "context"),
+    ("Cluster ADRs", "adr"),
+    ("For agents", "agents"),
+]
+
+
+def heading(path: Path) -> str:
+    for line in path.read_text().splitlines():
+        if line.startswith("# "):
+            return line[2:].strip()
+    sys.exit(f"{path.relative_to(ROOT)}: no H1 to label it with in the sidebar")
+
+
+def sidebar_render() -> str:
+    """Links are absolute on purpose. docsify runs with relativePath enabled so
+    that the ../adr/ links written inside docs/context/ resolve untouched — but
+    that also resolves sidebar links against whichever page is open, so a
+    root-relative nav compounds into /docs/docs/docs/… on every click. A leading
+    slash opts out. docs/README.md is deliberately absent: it introduces the
+    directory to someone browsing GitHub, and its links point at directories,
+    which docsify cannot render.
+    """
+    out = ["- [Map — glossary & routing](/CONTEXT.md)"]
+    for label, sub in SIDEBAR_SECTIONS:
+        out += ["", f"- **{label}**"]
+        for path in sorted((ROOT / "docs" / sub).glob("*.md")):
+            # Four spaces, because oxfmt reindents nested list items to four on
+            # commit and would otherwise rewrite this file into permanent staleness.
+            out.append(f"    - [{heading(path)}](/docs/{sub}/{path.name})")
+    out += ["", "- [Worklog](/docs/WORKLOG.md)"]
+    return "\n".join(out) + "\n"
+
+
+# --------------------------------------------------------------------------
 # registry
 # --------------------------------------------------------------------------
 
@@ -241,6 +283,23 @@ def main() -> int:
         else:
             path.write_text(updated)
             print(f"wrote docs/context/{filename}")
+
+    # Wholly generated, so it is simply compared and overwritten.
+    want = sidebar_render()
+    current = SIDEBAR.read_text() if SIDEBAR.exists() else ""
+    if current == want:
+        print("ok    _sidebar.md")
+    elif args.check:
+        stale = True
+        print("\n".join(difflib.unified_diff(
+            current.split("\n"), want.split("\n"),
+            fromfile="committed/_sidebar.md", tofile="disk/_sidebar.md",
+            lineterm="",
+        )))
+        print("stale _sidebar.md")
+    else:
+        SIDEBAR.write_text(want)
+        print("wrote _sidebar.md")
 
     if stale:
         print("\nRun `just docs generate` to update.")

--- a/index.html
+++ b/index.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Documentation for the home-ops cluster" />
+    <title>home-ops docs</title>
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@5/dist/themes/core.min.css" />
+  </head>
+  <body>
+    <div id="app">Loading…</div>
+    <script>
+      window.$docsify = {
+        name: 'home-ops',
+        repo: 'tscibilia/home-ops',
+
+        // CONTEXT.md is the map, so it is the front page — not the showcase README.
+        homepage: 'CONTEXT.md',
+
+        // Resolve links the way a filesystem does, so `docs/adr/x.md` from
+        // CONTEXT.md and `../adr/x.md` from docs/context/ both work as written.
+        // Nothing in the docs is authored for this site.
+        relativePath: true,
+
+        // The trade-off of relativePath: docsify also resolves sidebar links
+        // against the current page, and looks for _sidebar.md in the current
+        // directory. Absolute links in _sidebar.md handle the first (see
+        // docs/scripts/generate.py); this alias handles the second.
+        loadSidebar: true,
+        alias: {
+          '/.*/_sidebar.md': '/_sidebar.md',
+        },
+
+        subMaxLevel: 2,
+        maxLevel: 3,
+        auto2top: true,
+
+        search: {
+          depth: 3,
+          placeholder: 'Search the docs…',
+          noData: 'No matches.',
+        },
+      };
+    </script>
+    <script src="//cdn.jsdelivr.net/npm/docsify@5"></script>
+    <script src="//cdn.jsdelivr.net/npm/docsify@5/dist/plugins/search.min.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Restores a browsable docs site after the MkDocs one was dropped in 565d9652e, without reintroducing what killed it: that site required docs/apps/*.md, a hand-typed mirror of the cluster. This one renders the committed markdown in place — no second copy, no build step, no workflow. GitHub Pages serves the branch directly.

The site root is the repo root, not docs/, because the docs link outward to docker/vps/MIGRATION.md, kubernetes/bootstrap/cnpg/README.md and others, and those link onward again — a docs-only root cannot be closed.

relativePath keeps every existing link working as written: docs/adr/x.md from CONTEXT.md and ../adr/x.md from docs/context/ both resolve, so no file was edited to suit the renderer. Its trade-off is that docsify also resolves sidebar links against the open page, which compounds into /docs/docs/docs/... on each click; absolute links in _sidebar.md and an alias for the per-directory sidebar lookup handle both halves.

.nojekyll is required — Pages runs Jekyll by default, which silently drops files beginning with an underscore, so _sidebar.md would 404 in production and nowhere else.

generate.py gains a second output kind. Blocks are spliced into docs/context/ and guarded, because hand-written prose lives inside them; _sidebar.md is generated whole from each file's H1, so there is nothing to preserve and no guard. It stays under `just docs generate` rather than getting its own recipe — a second command to remember is a second way to ship a stale nav — and reports as its own line in `just docs test`.

docs/README.md is excluded from the site. It introduces the directory to someone browsing GitHub and links to directories, which docsify renders as 404s.

Publishing still requires setting Pages to deploy from this branch at the repo root.