### PR TITLE
fix(guacamole): auth via tinyauth header instead of broken OIDC

### DIFF
--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -17,13 +17,14 @@
 - [ ] ⚠️ **Fairtrail:** Chromium 146 crashes even when run as root (Alpine or Talos issue?) - **Likely abandoning this app**
 - [ ] ⚠️ **Donetick:** SSE realtime disconnects through Cloudflare tunnel - **consider trying again with pangolin**
 - [ ] ⚠️ **RustFS:** authentik-Admin -> rustfsAdmin, Plex Users need a RustFS group policy for access - **AI assist**
-- [ ] ⚠️ **Guacamole:** OpenID ext only supports implicit flow (`response_type=id_token`), pocket-id rejects it with `unsupported_response_type` - **needs auth-code-flow support upstream, or front it with ext-auth instead**
+- [ ] ⚠️ **Guacamole:** OpenID ext only supports implicit flow (`response_type=id_token`), pocket-id rejects it with `unsupported_response_type` - (see upstream issue [#1200](https://issues.apache.org/jira/browse/GUACAMOLE-1200))
 - [ ] ⚠️ **ComfyUI:** not working due to single gpu and single model loaded via `llmkube`
 
 ## ⛔ Blocked
 
 `- ⛔ **App name** - blocking factor (waiting for X) - **note**`
 
+- ⛔ **Guacamole:** OpenID with auth-code-flow & PKCE (see proposed PR [#1219](https://redirect.github.com/apache/guacamole-client/pull/1219))
 - ⛔ **CNPG** upstream bug summarized in issue #2301 causes `scheduledBackups` to get stuck infinitely - **upstream confirmed fix in 1.30.x**
 - ⛔ **etcd:** noisy logging, [see upstream](https://redirect.github.com/kubernetes/kubernetes/issues/134080) - **upstream confirmed fix in 1.37**
 - ⛔ move github to forgejo - **Unsure of decentralize bootstrap, postponed**

--- a/docs/context/apps.md
+++ b/docs/context/apps.md
@@ -145,7 +145,7 @@ Full list by namespace. The source of truth is `kubernetes/apps/`; the list belo
 - fluent-bit
 - gatus _(health monitoring)_ [cnpg]
 - grafana-operator _(Grafana operator + instance)_ [cnpg, oidc]
-- guacamole _(remote desktop)_ [cnpg, oidc]
+- guacamole _(remote desktop)_ [cnpg, auth, oidc]
 - karma _(alertmanager UI)_
 - kite [cnpg, oidc]
 - kromgo

--- a/kubernetes/apps/observability/guacamole/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/guacamole/app/helmrelease.yaml
@@ -53,7 +53,12 @@ spec:
             env:
               GUACAMOLE_HOME: /guacamole
               WEBAPP_CONTEXT: ROOT
-              EXTENSION_PRIORITY: "openid, postgresql, ban"
+              EXTENSION_PRIORITY: "header, postgresql, ban"
+              # pocket-id rejects the openid ext's implicit flow. Disabled (secret
+              # stays mounted) in favour of tinyauth asserting Remote-User, until
+              # GUACAMOLE-2258 / guacamole-client#1219 lands auth-code flow.
+              OPENID_ENABLED: "false"
+              HTTP_AUTH_HEADER: Remote-User
             envFrom:
               - secretRef:
                   name: guacamole-secret
@@ -77,11 +82,15 @@ spec:
     service:
       app:
         controller: *app
+        annotations:
+          gatus.home-operations.com/enabled: "true"
         ports:
           http:
             port: &port 8080
     route:
       app:
+        annotations:
+          gatus.home-operations.com/enabled: "false"
         hostnames: ["${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}"]
         parentRefs:
           - name: envoy-internal

--- a/kubernetes/apps/observability/guacamole/ks.yaml
+++ b/kubernetes/apps/observability/guacamole/ks.yaml
@@ -22,6 +22,7 @@ metadata:
   name: &app guacamole
 spec:
   components:
+    - ../../../../components/auth
     - ../../../../components/cnpg
   dependsOn:
     - name: secret-stores

--- a/kubernetes/components/auth/securitypolicy.yaml
+++ b/kubernetes/components/auth/securitypolicy.yaml
@@ -24,6 +24,7 @@ spec:
       headersToBackend:
         - Location
         - Set-Cookie
+        - Remote-User
   targetRefs:
     - group: "${EXT_AUTH_GROUP:-gateway.networking.k8s.io}"
       kind: "${EXT_AUTH_KIND:-HTTPRoute}"


### PR DESCRIPTION
pocket-id rejects the openid extension's implicit flow with unsupported_response_type. Disable that extension and trust tinyauth's Remote-User via the header extension instead.

OPENID_ENABLED=false leaves guacamole-oidc-secret mounted so this reverts in one line once GUACAMOLE-2258 / guacamole-client#1219 lands auth-code flow upstream.

Remote-User maps to preferred_username on both sides, so existing DB usernames need no migration. Envoy's allowed_upstream_headers overrides any client-supplied value, so the header cannot be spoofed through the gateway.