### PR TITLE
fix(bootstrap): stop akeyless CLI stderr landing inside secret values

### DIFF
--- a/kubernetes/bootstrap/scripts/akeyless-inject.sh
+++ b/kubernetes/bootstrap/scripts/akeyless-inject.sh
@@ -51,7 +51,9 @@ set -Eeuo pipefail
 #     Returns: The value of "TOKEN" from the nested JSON secret
 #
 # Notes:
-#   - The script processes input line by line and replaces ALL ak:// references
+#   - The script processes the whole input at once and replaces ALL ak:// references
+#   - Secret values may span multiple lines (PEM keys, certificates)
+#   - Each distinct secret is fetched once; hits and misses are both memoized
 #   - Failed secret lookups will cause the script to exit with an error
 #   - Set LOG_LEVEL environment variable to control verbosity (debug/info/warn/error)
 #   - Strips carriage returns (\r) for cross-platform compatibility
@@ -67,6 +69,7 @@ if [[ ! -f "$COMMON_LIB" ]]; then
   exit 1
 fi
 
+# shellcheck source=kubernetes/bootstrap/scripts/lib/common.sh
 source "$COMMON_LIB"
 
 # Ensure required CLIs are present, common.sh will exit on failure
@@ -80,7 +83,32 @@ if [[ ! -f "$input_file" && "$input_file" != "/dev/stdin" ]]; then
   exit 1
 fi
 
-# Resolve ak:// references
+# Memoized lookups. Cached entries are prefixed: "H" = hit, "M" = miss.
+declare -A secret_cache=()
+
+# Fetch one secret by exact name. Sets FETCHED, returns 1 if the name does not exist.
+fetch_secret() {
+  local name="$1"
+
+  if [[ -n "${secret_cache[$name]+set}" ]]; then
+    local cached="${secret_cache[$name]}"
+    log debug "Cache hit" "name=$name"
+    [[ "${cached:0:1}" == "H" ]] || return 1
+    FETCHED="${cached:1}"
+    return 0
+  fi
+
+  # 2>/dev/null, not 2>&1: CLI diagnostics must never land inside the secret value
+  if FETCHED=$(akeyless get-secret-value --name "$name" 2>/dev/null); then
+    secret_cache["$name"]="H${FETCHED}"
+    return 0
+  fi
+
+  secret_cache["$name"]="M"
+  return 1
+}
+
+# Resolve one ak:// reference. Sets RESOLVED.
 resolve_secret() {
   local ref="$1"
   local path="${ref#ak://}"   # strip scheme
@@ -91,10 +119,9 @@ resolve_secret() {
   log debug "Resolving secret reference" "ref=$ref" "path=$path"
 
   # Try as full path first (plain text or nested secret)
-  local secret_value
-  if secret_value=$(akeyless get-secret-value --name "$path" 2>&1); then
+  if fetch_secret "$path"; then
     log debug "Resolved as full-path secret" "name=$path"
-    printf '%s' "$secret_value"
+    RESOLVED="$FETCHED"
     return 0
   fi
 
@@ -106,10 +133,10 @@ resolve_secret() {
     log debug "Attempting JSON field extraction" "name=$secret_name" "key=$json_key"
 
     # Fetch secret
-    local secret_json
-    if ! secret_json=$(akeyless get-secret-value --name "$secret_name" 2>&1); then
+    if ! fetch_secret "$secret_name"; then
       log error "Failed to fetch secret from Akeyless" "name=$secret_name"
     fi
+    local secret_json="$FETCHED"
 
     # Validate key exists
     if ! echo "$secret_json" | jq -e "has(\"$json_key\")" > /dev/null 2>&1; then
@@ -117,11 +144,10 @@ resolve_secret() {
     fi
 
     # Extract value
-    if ! secret_value=$(echo "$secret_json" | jq -r ".\"$json_key\"" 2>&1); then
+    if ! RESOLVED=$(echo "$secret_json" | jq -r ".\"$json_key\"" 2>/dev/null); then
       log error "Failed to extract key from secret" "name=$secret_name" "key=$json_key"
     fi
 
-    printf '%s' "$secret_value"
     return 0
   fi
 
@@ -129,22 +155,22 @@ resolve_secret() {
   log error "Secret not found" "name=$path"
 }
 
-# Process input line by line
-while IFS= read -r line || [[ -n "$line" ]]; do
-  # Match ak:// tokens (alphanumeric, slashes, dots, hyphens, underscores)
-  while [[ "$line" =~ (ak://[a-zA-Z0-9/_.-]+) ]]; do
-    token="${BASH_REMATCH[1]}"
+# Process the whole input at once so multi-line secret values survive substitution
+content=$(cat "$input_file")
 
-    log debug "Found token"
+# Match ak:// tokens (alphanumeric, slashes, dots, hyphens, underscores)
+while [[ "$content" =~ (ak://[a-zA-Z0-9/_.-]+) ]]; do
+  token="${BASH_REMATCH[1]}"
 
-    # Resolve the secret
-    secret_value=$(resolve_secret "$token")
+  log debug "Found token"
 
-    log debug "Replacing token with" "$token"
+  # Resolve the secret
+  resolve_secret "$token"
 
-    # Replace token with value
-    line="${line/"$token"/"$secret_value"}"
-  done
+  log debug "Replacing token with" "$token"
 
-  echo "$line"
-done < "$input_file"
+  # First occurrence only, then rescan. Repeats are free: the fetch is cached.
+  content="${content/"$token"/"$RESOLVED"}"
+done
+
+printf '%s\n' "$content"


### PR DESCRIPTION
## Summary

`akeyless-inject.sh` resolves `ak://` references in the Talos and bootstrap templates at apply time. This PR fixes a latent correctness bug that could silently inject CLI diagnostic text into rendered secrets, and roughly halves the number of Akeyless API calls a render costs.

Rendered output is **byte-identical** to `main` for both templates that use the script.

---

## Changes

| # | Change | Why | Risk |
|---|--------|-----|------|
| 1 | `get-secret-value ... 2>&1` → `2>/dev/null` | stderr was being captured *into* the secret value | Fixes a silent-corruption bug |
| 2 | Memoize lookups (hits **and** misses) in `fetch_secret` | Every reference re-hit the API, including the probe that is expected to fail | None — pure caching, same values |
| 3 | Process whole input instead of line-by-line | Needed so the cache survives; the old `$( )` call site put resolution in a subshell | None — output verified identical |
| 4 | `# shellcheck source=` directive | Pre-existing `SC1090` blocked the pre-commit hook | None — comment only |

Diff: **1 file, +49 / −23**.

---

## Bug 1 — CLI stderr landed inside secret values

The old line captured both streams:

```bash
secret_value=$(akeyless get-secret-value --name "$path" 2>&1)
```

If the `akeyless` CLI writes anything to stderr on an otherwise **successful** fetch, that text became part of the secret.

| Secret type | Old behaviour | New behaviour |
|---|---|---|
| Plain text | CLI noise appended to the value, injected into the rendered config | Clean value |
| JSON | `jq` cannot parse it → script aborts with the misleading error `Key not found in secret` | Parses correctly |

Reproduced with a stub CLI that emits one benign stderr line on success: the old script **exits 1** on any JSON secret, the new one exits 0.

---

## Bug 2 — prefix-colliding references (caught during review)

An intermediate version of this branch used bash replace-all (`${content//…}`). That is **wrong** for this repo, because reference names collide by prefix:

| Template | Short name | Longer name containing it |
|---|---|---|
| `kubernetes/talos/machineconfig.yaml.j2` | `ak://talos-m70q/CLUSTER_SECRET` | `ak://talos-m70q/CLUSTER_SECRETBOXENCRYPTIONSECRET` |
| `kubernetes/bootstrap/kustomize/resources.yaml.j2` | `ak://kubernetes/akeyless/AK_ACCESS_TYPE` | `ak://kubernetes/akeyless/AK_ACCESS_TYPE_PARAM` |

Replace-all rewrote the short name *inside* the long one. With placeholder values:

```text
replace-all:  l: SHORT-VALBOXENCRYPTIONSECRET   ← corrupt
fixed:        l: LONG-VAL                       ← correct
```

The merged version keeps the original first-occurrence-then-rescan semantics, which are positional and therefore immune to this. Repeated references are still cheap because the fetch is cached:

```bash
# First occurrence only, then rescan. Repeats are free: the fetch is cached.
content="${content/"$token"/"$RESOLVED"}"
```

Regression tests cover both orderings (short-before-long and long-before-short) and were confirmed to **fail** against the replace-all version.

---

## API call counts

Old code made two calls per *occurrence* (a full-path probe that misses, then the parent JSON secret). New code makes one call per *distinct* name, cached.

| Template | Refs (total / distinct) | Calls before | Calls after |
|---|---|---|---|
| `machineconfig.yaml.j2` | 18 / 18 | 36 | 20 |
| `resources.yaml.j2` | 9 / 7 | 18 | 10 |
| stub fixture (repeats) | 6 / 4 | 10 | 5 |

Call counts only. Wall-clock time was not measured.

---

## Verification

| Check | Result |
|---|---|
| `sha256sum` of rendered `machineconfig.yaml.j2` vs `main` | Identical |
| `sha256sum` of rendered `resources.yaml.j2` vs `main` | Identical |
| Stub test suite | 32 / 32 pass |
| `bash -n` | Clean |
| `shellcheck` (repo root and script dir) | Clean |

The stub suite uses a fake `akeyless` binary returning canned values — **no real secrets were read during testing**. It covers: plain secrets, nested paths, JSON field extraction, empty values, multi-line PEM values, multiple tokens per line, files with no references, missing secrets (must still exit 1), stdin mode, prefix collisions, and byte-for-byte output shape including trailing newlines.

---

## Not changed

- Reference syntax (`ak://path`, `ak://path/FIELD`) — unchanged.
- Lookup precedence — still full path first, then JSON field extraction. Deliberately left alone; inverting it would change which secret wins when both exist.
- Error behaviour — a missing secret still aborts the run with exit 1.
- `lib/common.sh` — untouched.
