### PR TITLE
fix(doco-cd): run akeyless-proxy as the host user owning the secret

### DIFF
--- a/docker/clonenas/.doco-cd/docker-compose.app.yaml
+++ b/docker/clonenas/.doco-cd/docker-compose.app.yaml
@@ -57,6 +57,10 @@ services:
     image: ghcr.io/tscibilia/akeyless-proxy:0.0.1@sha256:1da58e8c7d5475a51bf1a8c7ed3877bb513fcca6b2b4b7c4e4dc4214e0ed2cde
     container_name: akeyless-proxy
     restart: unless-stopped
+    # The image runs as `nobody`. Compose bind-mounts the secret files with
+    # their host permissions (0600 sysadmin:sysadmin), so the container must
+    # run as the host user that owns them or it exits on PermissionError.
+    user: "3000:3000"
     networks:
       - doco-cd
     expose:

--- a/docker/truenas/.doco-cd/docker-compose.app.yaml
+++ b/docker/truenas/.doco-cd/docker-compose.app.yaml
@@ -58,6 +58,10 @@ services:
     image: ghcr.io/tscibilia/akeyless-proxy:0.0.1@sha256:1da58e8c7d5475a51bf1a8c7ed3877bb513fcca6b2b4b7c4e4dc4214e0ed2cde
     container_name: akeyless-proxy
     restart: unless-stopped
+    # The image runs as `nobody`. Compose bind-mounts the secret files with
+    # their host permissions (0600 sysadmin:sysadmin), so the container must
+    # run as the host user that owns them or it exits on PermissionError.
+    user: "3000:3000"
     networks:
       - doco-cd
     expose:

--- a/docker/vps/.doco-cd/docker-compose.app.yaml
+++ b/docker/vps/.doco-cd/docker-compose.app.yaml
@@ -57,6 +57,10 @@ services:
     image: ghcr.io/tscibilia/akeyless-proxy:0.0.1@sha256:1da58e8c7d5475a51bf1a8c7ed3877bb513fcca6b2b4b7c4e4dc4214e0ed2cde
     container_name: akeyless-proxy
     restart: unless-stopped
+    # The image runs as `nobody`. Compose bind-mounts the secret files with
+    # their host permissions (0600 ubuntu:ubuntu), so the container must run
+    # as the host user that owns them or it exits on PermissionError.
+    user: "1000:1000"
     expose:
       - "8080"
     environment:


### PR DESCRIPTION
The published image sets USER nobody. The locally-built image it replaced ran as root, so the difference only surfaced at deploy time:

  PermissionError: [Errno 13] Permission denied:
  /run/secrets/akeyless_access_id

Compose bind-mounts file-based secrets with their host permissions, and Ansible writes them 0600 owned by the host's own user. uid/gid mode on a secret definition is swarm-only and is ignored here, so the container has to run as that user.