### PR TITLE
feat(hermes): sign agent commits with an SSH key

### DIFF
--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -18,9 +18,8 @@ spec:
         ## Connections
         SECRET_DOMAIN: "{{ .SECRET_DOMAIN }}"
         GITHUB_TOKEN: "{{ .GH_HERMES_TOKEN }}"
-        # GITHUB_APP_ID: "{{ .KONFLATE_APP_CLIENT_ID }}"
-        # GITHUB_APP_PRIVATE_KEY_PATH: "{{ .KONFLATE_APP_PRIVATE_KEY }}"
-        # GITHUB_APP_INSTALLATION_ID: ""
+        # Private half of an SSH signing key (not an Authentication Key)
+        GH_HERMES_SIGNING_KEY: "{{ .GH_HERMES_SIGNING_KEY }}"
         PHOTON_PROJECT_ID: "{{ .PHOTON_PROJECT_ID }}"
         PHOTON_PROJECT_SECRET: "{{ .PHOTON_PROJECT_SECRET }}"
         DISCORD_BOT_TOKEN: "{{ .DISCORD_BOT_TOKEN }}"

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -51,6 +51,12 @@ spec:
                 # Overwrites any agent self-edit — SOUL.md is GitOps-owned.
                 cp /run/config/SOUL.md /opt/data/SOUL.md
                 chown 10000:10000 /opt/data/SOUL.md
+                # SSH commit-signing key. ssh-keygen refuses a key that is group
+                # or world readable, so 0600 is load-bearing, not hygiene.
+                mkdir -p /opt/data/.ssh
+                chmod 700 /opt/data/.ssh
+                printf '%s\n' "$$GH_HERMES_SIGNING_KEY" > /opt/data/.ssh/hermes_signing
+                chmod 600 /opt/data/.ssh/hermes_signing
             securityContext:
               allowPrivilegeEscalation: false
               capabilities: { drop: ["ALL"] }
@@ -111,11 +117,21 @@ spec:
               HOMEBREW_PREFIX: /opt/data/.local/homebrew
               HOMEBREW_REPOSITORY: /opt/data/.local/homebrew
               GATEWAY_ALLOW_ALL_USERS: true
-              # No ~/.gitconfig on the PVC, so `git commit` has no identity.
+              # No ~/.gitconfig on the PVC, so `git commit` has no identity and no signing
+              # config. GIT_CONFIG_COUNT/KEY/VALUE supplies both without writing a file.
               GIT_AUTHOR_NAME: &gitUser hermes
-              GIT_AUTHOR_EMAIL: &gitEmail hermes@users.noreply.github.com
+              GIT_AUTHOR_EMAIL: &gitEmail 585808+tscibilia@users.noreply.github.com
               GIT_COMMITTER_NAME: *gitUser
               GIT_COMMITTER_EMAIL: *gitEmail
+              GIT_CONFIG_COUNT: "4"
+              GIT_CONFIG_KEY_0: gpg.format
+              GIT_CONFIG_VALUE_0: ssh
+              GIT_CONFIG_KEY_1: user.signingkey
+              GIT_CONFIG_VALUE_1: /opt/data/.ssh/hermes_signing
+              GIT_CONFIG_KEY_2: commit.gpgsign
+              GIT_CONFIG_VALUE_2: "true"
+              GIT_CONFIG_KEY_3: tag.gpgsign
+              GIT_CONFIG_VALUE_3: "true"
               GOPATH: /opt/data/go
               PATH: /opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
               PIP_BREAK_SYSTEM_PACKAGES: "1"


### PR DESCRIPTION
home-ops and three sibling repos now carry a required_signatures rule on the
default branch. Hermes commits were unsigned, which blocks merge-commit and
rebase-merge outright and leaves squash working only by accident — it succeeds
because the agent opens PRs with Tom's PAT and so counts as the PR author.

Ship a signing key instead. The private half comes from aKeyless as
GH_HERMES_SIGNING_KEY and 02-init-config writes it to /opt/data/.ssh at 0600;
ssh-keygen refuses a key that is group or world readable, so the mode is
load-bearing rather than hygiene. The public half is registered on the GitHub
account as a Signing Key.

Configure git through GIT_CONFIG_COUNT/KEY/VALUE rather than a .gitconfig,
matching how the identity is already supplied — the PVC has no ~/.gitconfig and
adding one would be mutable state outside git.

Switch the commit email to Tom's GitHub noreply. A signature only renders
Verified when the author email is a verified address on the account holding the
key, so hermes@users.noreply.github.com would have signed and still shown
Unverified. The author name stays hermes; the email is the load-bearing half.

Drop the commented-out GITHUB_APP_* lines. The token path is what is in use and
the GitHub App path was never wired.
