### PR TITLE
docs(adr): record how the Hermes agent is identified and constrained

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,25 +66,27 @@ For sub-directory specifics not covered above, read that directory's `README.md`
 
 Read the ADRs touching the area you're about to work in. Don't re-litigate a recorded decision; if you think one is wrong, supersede it.
 
-| #                                                              | Decision                                                    | Date       | Status                  |
-| -------------------------------------------------------------- | ----------------------------------------------------------- | ---------- | ----------------------- |
-| [0001](docs/adr/0001-follow-onedr0p-cluster-template.md)       | Follow onedr0p's cluster-template and his home-ops patterns | 2025-03-24 | accepted · living table |
-| [0002](docs/adr/0002-flux-repository-conventions.md)           | Flux repository conventions                                 | —          | accepted · living table |
-| [0003](docs/adr/0003-external-secrets-akeyless-over-sops.md)   | External Secrets Operator with aKeyless, replacing SOPS     | 2025-04-06 | accepted                |
-| [0004](docs/adr/0004-cloudnativepg-for-postgresql.md)          | CloudNativePG for PostgreSQL                                | 2025-04-21 | accepted                |
-| [0005](docs/adr/0005-volsync-for-pvc-backup.md)                | VolSync for PVC backup                                      | 2025-04-23 | superseded by 0013      |
-| [0006](docs/adr/0006-authentik-for-sso.md)                     | Authentik for SSO                                           | 2025-05-01 | superseded by 0014      |
-| [0007](docs/adr/0007-keda-for-scale-to-zero.md)                | KEDA for scale-to-zero                                      | 2025-06-14 | superseded by 0010      |
-| [0008](docs/adr/0008-envoy-gateway-over-ingress-nginx.md)      | Envoy Gateway over ingress-nginx                            | 2025-10-21 | accepted                |
-| [0009](docs/adr/0009-pangolin-for-external-ingress.md)         | Pangolin for external ingress                               | 2026-05-02 | superseded by 0015      |
-| [0010](docs/adr/0010-zeroscaler-over-keda.md)                  | zeroscaler (native HPA + prometheus-adapter) over KEDA      | 2026-05-17 | accepted                |
-| [0011](docs/adr/0011-pgvector-cluster-split.md)                | Separate pgvector cluster for vector workloads              | 2026-05-21 | accepted                |
-| [0012](docs/adr/0012-konflate-over-flux-local.md)              | konflate (flate) over flux-local                            | 2026-06-18 | accepted                |
-| [0013](docs/adr/0013-kopiur-over-volsync.md)                   | kopiur over VolSync for PVC backup                          | 2026-07-05 | accepted                |
-| [0014](docs/adr/0014-pocket-id-tinyauth-over-authentik.md)     | pocket-id and tinyauth over Authentik                       | 2026-08-05 | accepted                |
-| [0015](docs/adr/0015-towonel-over-pangolin.md)                 | towonel over Pangolin for public ingress                    | 2026-08-08 | accepted                |
-| [0016](docs/adr/0016-no-http3-on-envoy-gateways.md)            | No HTTP/3 on the Envoy gateways                             | 2026-08-10 | accepted                |
-| [0017](docs/adr/0017-akeyless-github-action-for-ci-secrets.md) | aKeyless GitHub Action for CI secrets, over GitHub secrets  | 2026-08-13 | accepted                |
+| #                                                                    | Decision                                                    | Date       | Status                  |
+| -------------------------------------------------------------------- | ----------------------------------------------------------- | ---------- | ----------------------- |
+| [0001](docs/adr/0001-follow-onedr0p-cluster-template.md)             | Follow onedr0p's cluster-template and his home-ops patterns | 2025-03-24 | accepted · living table |
+| [0002](docs/adr/0002-flux-repository-conventions.md)                 | Flux repository conventions                                 | —          | accepted · living table |
+| [0003](docs/adr/0003-external-secrets-akeyless-over-sops.md)         | External Secrets Operator with aKeyless, replacing SOPS     | 2025-04-06 | accepted                |
+| [0004](docs/adr/0004-cloudnativepg-for-postgresql.md)                | CloudNativePG for PostgreSQL                                | 2025-04-21 | accepted                |
+| [0005](docs/adr/0005-volsync-for-pvc-backup.md)                      | VolSync for PVC backup                                      | 2025-04-23 | superseded by 0013      |
+| [0006](docs/adr/0006-authentik-for-sso.md)                           | Authentik for SSO                                           | 2025-05-01 | superseded by 0014      |
+| [0007](docs/adr/0007-keda-for-scale-to-zero.md)                      | KEDA for scale-to-zero                                      | 2025-06-14 | superseded by 0010      |
+| [0008](docs/adr/0008-envoy-gateway-over-ingress-nginx.md)            | Envoy Gateway over ingress-nginx                            | 2025-10-21 | accepted                |
+| [0009](docs/adr/0009-pangolin-for-external-ingress.md)               | Pangolin for external ingress                               | 2026-05-02 | superseded by 0015      |
+| [0010](docs/adr/0010-zeroscaler-over-keda.md)                        | zeroscaler (native HPA + prometheus-adapter) over KEDA      | 2026-05-17 | accepted                |
+| [0011](docs/adr/0011-pgvector-cluster-split.md)                      | Separate pgvector cluster for vector workloads              | 2026-05-21 | accepted                |
+| [0012](docs/adr/0012-konflate-over-flux-local.md)                    | konflate (flate) over flux-local                            | 2026-06-18 | accepted                |
+| [0013](docs/adr/0013-kopiur-over-volsync.md)                         | kopiur over VolSync for PVC backup                          | 2026-07-05 | accepted                |
+| [0014](docs/adr/0014-pocket-id-tinyauth-over-authentik.md)           | pocket-id and tinyauth over Authentik                       | 2026-08-05 | accepted                |
+| [0015](docs/adr/0015-towonel-over-pangolin.md)                       | towonel over Pangolin for public ingress                    | 2026-08-08 | accepted                |
+| [0016](docs/adr/0016-no-http3-on-envoy-gateways.md)                  | No HTTP/3 on the Envoy gateways                             | 2026-08-10 | accepted                |
+| [0017](docs/adr/0017-akeyless-github-action-for-ci-secrets.md)       | aKeyless GitHub Action for CI secrets, over GitHub secrets  | 2026-08-13 | accepted                |
+| [0018](docs/adr/0018-soul-for-identity-channel-prompts-for-rules.md) | SOUL.md carries identity; channel_prompts carry room rules  | 2026-08-16 | accepted                |
+| [0019](docs/adr/0019-agent-opens-prs-cannot-land-them.md)            | The Hermes agent opens pull requests and cannot land them   | 2026-08-16 | accepted                |
 
 **0005, 0006, 0007 and 0009 are reconstructed** — written after the fact from the commits that removed them, not from contemporaneous notes. Each says so. Trust their consequences more than their rationale.
 

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -28,6 +28,8 @@
     - [towonel over Pangolin for public ingress](/docs/adr/0015-towonel-over-pangolin.md)
     - [No HTTP/3 on the Envoy gateways](/docs/adr/0016-no-http3-on-envoy-gateways.md)
     - [aKeyless GitHub Action for CI secrets, replacing GitHub repository secrets](/docs/adr/0017-akeyless-github-action-for-ci-secrets.md)
+    - [SOUL.md carries identity; per-room operating rules live in channel_prompts](/docs/adr/0018-soul-for-identity-channel-prompts-for-rules.md)
+    - [The Hermes agent opens pull requests and cannot land them](/docs/adr/0019-agent-opens-prs-cannot-land-them.md)
 
 - **For agents**
     - [Domain Docs](/docs/agents/domain.md)

--- a/docs/adr/0018-soul-for-identity-channel-prompts-for-rules.md
+++ b/docs/adr/0018-soul-for-identity-channel-prompts-for-rules.md
@@ -1,0 +1,21 @@
+# SOUL.md carries identity; per-room operating rules live in channel_prompts
+
+**Status:** accepted
+**Date:** 2026-08-16
+
+Hermes reads `$HERMES_HOME/SOUL.md` as slot #1 of the system prompt, replacing its built-in identity outright. home-ops ships that file as `kubernetes/apps/ai/hermes/app/resources/SOUL.md` through a `configMapGenerator`, and the `02-init-config` initContainer copies it over `/opt/data/SOUL.md` on every start. It carries voice, disposition and universal restrictions only. Everything specific to a room — the homelab operating manual for `#hermes-k8s`, the assistant brief for `#hermes-aid` — lives in `discord.channel_prompts`, keyed by Discord channel ID.
+
+## Considered options
+
+**Let the agent own SOUL.md on the PVC.** "The agent that grows with you" implies the identity file should be the agent's to rewrite. It cannot: no tool writes SOUL.md, and `tools/threat_patterns.py` classifies an injected instruction to edit it as a prompt-injection signature. The surfaces that do grow are the memory provider (memini, `MEMINI_NAMESPACE=tscibilia/hermes`) and the skills the agent authors under `/opt/data/skills` — both on the PVC, both untouched by this decision. GitOps ownership therefore costs no adaptability and buys review plus survival of a PVC loss.
+
+**One SOUL.md carrying the operating rules too.** Rejected on two grounds. Hermes joins three prompt tiers and SOUL sits in `stable`, which is built once per session and used as the upstream prefix cache; room-specific text there forks that prefix per room. Separately, the upstream guide draws the line explicitly — tone and disposition in SOUL.md, project rules in AGENTS.md — and calls confusing the two its most common mistake.
+
+**Hermes profiles.** The obvious answer, and the one community writing points at: `$HERMES_HOME/profiles/<name>/SOUL.md`. A profile is not a persona inside one agent but a separate instance — `hermes_cli/container_boot.py` reconciles "per-profile gateway s6 services", one gateway process per profile, each with its own `config.yaml`, `.env`, `SOUL.md` and skills. The deployment runs a single `gateway run`, so a second SOUL would mean a second gateway and a second Discord bot token to separate two rooms that differ only in subject matter.
+
+## Consequences
+
+- `channel_prompts` are appended below SOUL in the `context` tier, never replacing it. A forum parent's entry also covers its child threads, and an unmatched key is silently ignored — a stale channel ID fails quiet, with no error anywhere.
+- Channel IDs are quoted in YAML so the keys stay strings.
+- The initContainer copy is unconditional and overwrites anything already at `/opt/data/SOUL.md`. That is the point, and it is what makes the file in git the only source worth reading.
+- Project rules are **not** auto-loaded. Hermes discovers AGENTS.md from `terminal.cwd` (`/opt/data/workspace`) at session start, first-match-wins against `.hermes.md`/`CLAUDE.md`/`.cursorrules`, and the prompt is built once — `cd`-ing into a clone mid-session does not reload it. The `#hermes-k8s` prompt therefore tells the agent to read AGENTS.md and CONTEXT.md explicitly rather than assume them. Pointing `terminal.cwd` at a pre-cloned repo would make the load automatic and is the obvious follow-up.

--- a/docs/adr/0019-agent-opens-prs-cannot-land-them.md
+++ b/docs/adr/0019-agent-opens-prs-cannot-land-them.md
@@ -1,0 +1,24 @@
+# The Hermes agent opens pull requests and cannot land them
+
+**Status:** accepted
+**Date:** 2026-08-16
+
+The agent has a shell, `gh`, and a fine-grained PAT carrying read/write on code, issues and pull requests. It may clone, branch, commit and open a pull request. It may not put anything on a default branch. Enforcement is a GitHub ruleset per repository — server-side refusal, not agent configuration.
+
+## Considered options
+
+**The agent's own `approvals.deny` globs.** `approvals.deny` matches fnmatch patterns before the yolo bypass and carries entries for `git push*origin main*`, force-push, `gh pr merge*` and `gh repo delete*`. Kept, but not relied on: a bare `git push` from a branch with an upstream never matches any of them, and the whole mechanism is configuration the agent's own tooling chooses to honour rather than something the far end refuses.
+
+**A bypass for Repository admin, so the operator keeps direct pushes.** Rejected. The agent authenticates with the operator's PAT, so to GitHub it is the same actor holding the same role; a bypass granted to the human is inherited by the agent and the ruleset stops meaning anything. The cost is real and was paid deliberately — 18 of the 50 commits preceding this change went straight to `main`.
+
+**A separate machine account for the agent.** The only arrangement that gives both halves: the agent added as a write-level collaborator, the operator bypassing as admin. Deferred, not rejected. It needs a second GitHub account, collaborator invites per repo, its own PAT and signing key, and a matching `GIT_AUTHOR_EMAIL`.
+
+## Consequences
+
+- Rulesets are per repository. Organisation-wide rulesets exist only for organisations and `tscibilia` is a personal account, so each repo carries its own copy with an **empty bypass list** and `~DEFAULT_BRANCH` as the only condition. None of this lives in git; the GitHub console and this ADR are the whole record.
+- Applied to `home-ops`, `akeyless-proxy`, `greenlight` and `linkcard`: `deletion`, `required_signatures`, `non_fast_forward`, `pull_request` with **0 required approvals**. Requiring one would deadlock a single-maintainer repo, because GitHub forbids approving your own pull request.
+- `home-ops` additionally requires the `Image Pull - Success` check. That rule is deliberately **not** copied to the others — a required check that no workflow emits leaves every pull request unmergeable forever.
+- `ce-transcript` is unprotected and cannot be fixed. Rulesets on private repositories need a paid plan. The mitigation is to narrow the PAT to selected repositories and leave it out, so the agent cannot reach the one repo that cannot be defended.
+- `required_signatures` forces commit signing on the agent. Its commits are SSH-signed with a key delivered from aKeyless as `GH_HERMES_SIGNING_KEY`, written to `/opt/data/.ssh/hermes_signing` at 0600 by `02-init-config` — `ssh-keygen` refuses a group- or world-readable key, so the mode is load-bearing. Git is configured through `GIT_CONFIG_COUNT`/`KEY`/`VALUE` rather than a `.gitconfig`, matching how the commit identity is already supplied to a PVC that has none.
+- The agent commits as `hermes <585808+tscibilia@users.noreply.github.com>`. A signature renders **Unverified** unless the author email is a verified address on the account holding the key, so the agent's own noreply address will not serve. The consequence is that its commits are indistinguishable from the operator's in the audit trail — the strongest argument for the deferred machine account.
+- Rebase merging is disabled repository-wide. GitHub adds rebased commits to the base branch without signature verification and cannot sign them on the author's behalf, so rebase and `required_signatures` are incompatible. Merge commits and squash remain; squash takes the pull request title and body.


### PR DESCRIPTION
0018 records why SOUL.md carries only voice and universal restrictions while
per-room operating rules live in discord.channel_prompts. Three alternatives
were rejected for reasons the config does not show: the agent cannot edit
SOUL.md at all, room-specific text in SOUL forks the cached stable prompt
prefix, and a Hermes "profile" is a separate gateway process rather than a
persona, so a second SOUL would cost a second Discord bot token.

0019 records that the agent may open pull requests but not land them, that
enforcement is a per-repository GitHub ruleset rather than agent config, and
why a bypass for Repository admin was rejected — the agent uses the operator's
PAT, so any bypass granted to the human is inherited by the agent. The
rulesets, the 0-approval choice, the ce-transcript gap and the rebase/signing
incompatibility live only in the GitHub console, so they are written down here
as ADR-0017 does for its auth method.
