### PR TITLE
fix(hermes): let the agent see GITHUB_TOKEN in its shell

### DIFF
--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -200,6 +200,12 @@ data:
       cwd: /opt/data/workspace
       timeout: 180
       persistent_shell: true
+      # GITHUB_TOKEN is in _ALWAYS_STRIP_KEYS, so the terminal never sees it and
+      # both `git push` and `gh pr create` fail with no credential. This is the
+      # sanctioned opt-in that re-admits it — the PR workflow is the whole point
+      # of giving the agent a token, and the ruleset is what stops it landing.
+      env_passthrough:
+        - GITHUB_TOKEN
     toolsets:
       - hermes-cli
     web:


### PR DESCRIPTION
The terminal tool strips GITHUB_TOKEN and GH_TOKEN from every subprocess it
spawns via _ALWAYS_STRIP_KEYS, so the agent had a token in the container and no
token where it actually runs commands. Both git push and gh pr create failed
with no credential, and the agent correctly reported it had none.

terminal.env_passthrough is the sanctioned opt-in — _sanitize_subprocess_env
consults is_env_passthrough before stripping. An SSH key was considered and
rejected: it would fix git push but not gh pr create, and opening the PR is the
part that matters.

This re-exposes the token to anything running in the agent's shell, which is
what the strip was protecting against. The branch-protection rulesets remain
the control that stops the agent landing code, and narrowing the PAT to
selected repositories is now the more valuable follow-up.
