### PR TITLE
revert(hermes): don't provide github signing token

### DIFF
--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -200,12 +200,6 @@ data:
       cwd: /opt/data/workspace
       timeout: 180
       persistent_shell: true
-      # GITHUB_TOKEN is in _ALWAYS_STRIP_KEYS, so the terminal never sees it and
-      # both `git push` and `gh pr create` fail with no credential. This is the
-      # sanctioned opt-in that re-admits it — the PR workflow is the whole point
-      # of giving the agent a token, and the ruleset is what stops it landing.
-      env_passthrough:
-        - GITHUB_TOKEN
     toolsets:
       - hermes-cli
     web:


### PR DESCRIPTION
refusing to register Hermes provider credential 'GITHUB_TOKEN' from  config.yaml (blocked by _HERMES_PROVIDER_ENV_BLOCKLIST). Operator  configuration must not override the execute_code sandbox's credential  scrubbing; see GHSA-rhgp-j443-p4rf.