### PR TITLE
refactor: use url over grafanaCom for GrafanaDashboards

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/app/grafanadashboard.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/grafanadashboard.yaml
@@ -13,6 +13,4 @@ spec:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   # renovate: depName="Cert-manager-Kubernetes"
-  grafanaCom:
-    id: 20842
-    revision: 3
+  url: https://grafana.com/api/dashboards/20842/revisions/3/download

--- a/kubernetes/apps/kube-system/spegel/app/grafanadashboard.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/grafanadashboard.yaml
@@ -13,5 +13,4 @@ spec:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   folder: Networking
-  # renovate: depName="Spegel"
   url: https://grafana.com/api/dashboards/18089/revisions/1/download

--- a/kubernetes/apps/kube-system/spegel/app/grafanadashboard.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/grafanadashboard.yaml
@@ -14,6 +14,4 @@ spec:
       inputName: DS_PROMETHEUS
   folder: Networking
   # renovate: depName="Spegel"
-  grafanaCom:
-    id: 18089
-    revision: 1
+  url: https://grafana.com/api/dashboards/18089/revisions/1/download

--- a/kubernetes/apps/media/qui/app/grafanadashboard.yaml
+++ b/kubernetes/apps/media/qui/app/grafanadashboard.yaml
@@ -3,7 +3,7 @@
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  name: cert-manager
+  name: qui
 spec:
   allowCrossNamespaceImport: true
   instanceSelector:
@@ -12,4 +12,4 @@ spec:
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
-  url: https://grafana.com/api/dashboards/20842/revisions/3/download
+  url: https://grafana.com/api/dashboards/25156/revisions/1/download

--- a/kubernetes/apps/media/qui/app/kustomization.yaml
+++ b/kubernetes/apps/media/qui/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./pocketidoidcclient.yaml

--- a/kubernetes/apps/network/external-dns/app/grafanadashboard.yaml
+++ b/kubernetes/apps/network/external-dns/app/grafanadashboard.yaml
@@ -13,5 +13,4 @@ spec:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   folder: Networking
-  # renovate: depName="External-dns"
   url: https://grafana.com/api/dashboards/15038/revisions/3/download

--- a/kubernetes/apps/network/external-dns/app/grafanadashboard.yaml
+++ b/kubernetes/apps/network/external-dns/app/grafanadashboard.yaml
@@ -14,6 +14,4 @@ spec:
       inputName: DS_PROMETHEUS
   folder: Networking
   # renovate: depName="External-dns"
-  grafanaCom:
-    id: 15038
-    revision: 3
+  url: https://grafana.com/api/dashboards/15038/revisions/3/download

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/grafanadashboard.yaml
@@ -3,13 +3,14 @@
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  name: cert-manager
+  name: blackbox-exporter
 spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
       grafana.internal/instance: grafana
+  # dashboard 7587 declares its input as DS_SIGNCL-PROMETHEUS; inputName must match __inputs, not our DS name
   datasources:
     - datasourceName: prometheus
-      inputName: DS_PROMETHEUS
-  url: https://grafana.com/api/dashboards/20842/revisions/3/download
+      inputName: DS_SIGNCL-PROMETHEUS
+  url: https://grafana.com/api/dashboards/7587/revisions/3/download

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./probes.yaml

--- a/kubernetes/apps/observability/exporters/radarr-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/exporters/radarr-exporter/app/grafanadashboard.yaml
@@ -14,6 +14,4 @@ spec:
       inputName: DS_PROMETHEUS
   folder: Exporters
   # renovate: depName="Media / Radarr"
-  grafanaCom:
-    id: 12896
-    revision: 1
+  url: https://grafana.com/api/dashboards/12896/revisions/1/download

--- a/kubernetes/apps/observability/exporters/radarr-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/exporters/radarr-exporter/app/grafanadashboard.yaml
@@ -13,5 +13,4 @@ spec:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   folder: Exporters
-  # renovate: depName="Media / Radarr"
   url: https://grafana.com/api/dashboards/12896/revisions/1/download

--- a/kubernetes/apps/observability/exporters/sonarr-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/exporters/sonarr-exporter/app/grafanadashboard.yaml
@@ -13,5 +13,4 @@ spec:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   folder: Exporters
-  # renovate: depName="Media / Sonarr"
   url: https://grafana.com/api/dashboards/12530/revisions/2/download

--- a/kubernetes/apps/observability/exporters/sonarr-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/exporters/sonarr-exporter/app/grafanadashboard.yaml
@@ -14,6 +14,4 @@ spec:
       inputName: DS_PROMETHEUS
   folder: Exporters
   # renovate: depName="Media / Sonarr"
-  grafanaCom:
-    id: 12530
-    revision: 2
+  url: https://grafana.com/api/dashboards/12530/revisions/2/download

--- a/kubernetes/apps/observability/unpoller/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/unpoller/app/grafanadashboard.yaml
@@ -13,7 +13,6 @@ spec:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   folder: Unifi
-  # renovate: depName="UniFi-Poller: Client Insights - Prometheus"
   url: https://grafana.com/api/dashboards/11315/revisions/9/download
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
@@ -30,7 +29,6 @@ spec:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   folder: Unifi
-  # renovate: depName="UniFi-Poller: Network Sites - Prometheus"
   url: https://grafana.com/api/dashboards/11311/revisions/5/download
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
@@ -47,7 +45,6 @@ spec:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   folder: Unifi
-  # renovate: depName="UniFi-Poller: Client DPI - Prometheus"
   url: https://grafana.com/api/dashboards/11310/revisions/5/download
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
@@ -64,7 +61,6 @@ spec:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   folder: Unifi
-  # renovate: depName="UniFi-Poller: UAP Insights - Prometheus"
   url: https://grafana.com/api/dashboards/11314/revisions/10/download
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
@@ -81,7 +77,6 @@ spec:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   folder: Unifi
-  # renovate: depName="UniFi-Poller: USW Insights - Prometheus"
   url: https://grafana.com/api/dashboards/11312/revisions/9/download
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
@@ -98,5 +93,4 @@ spec:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   folder: Unifi
-  # renovate: depName="UniFi-Poller: USG Insights - Prometheus"
   url: https://grafana.com/api/dashboards/11313/revisions/9/download

--- a/kubernetes/apps/observability/unpoller/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/unpoller/app/grafanadashboard.yaml
@@ -14,9 +14,7 @@ spec:
       inputName: DS_PROMETHEUS
   folder: Unifi
   # renovate: depName="UniFi-Poller: Client Insights - Prometheus"
-  grafanaCom:
-    id: 11315
-    revision: 9
+  url: https://grafana.com/api/dashboards/11315/revisions/9/download
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
@@ -33,9 +31,7 @@ spec:
       inputName: DS_PROMETHEUS
   folder: Unifi
   # renovate: depName="UniFi-Poller: Network Sites - Prometheus"
-  grafanaCom:
-    id: 11311
-    revision: 5
+  url: https://grafana.com/api/dashboards/11311/revisions/5/download
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
@@ -52,9 +48,7 @@ spec:
       inputName: DS_PROMETHEUS
   folder: Unifi
   # renovate: depName="UniFi-Poller: Client DPI - Prometheus"
-  grafanaCom:
-    id: 11310
-    revision: 5
+  url: https://grafana.com/api/dashboards/11310/revisions/5/download
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
@@ -71,9 +65,7 @@ spec:
       inputName: DS_PROMETHEUS
   folder: Unifi
   # renovate: depName="UniFi-Poller: UAP Insights - Prometheus"
-  grafanaCom:
-    id: 11314
-    revision: 10
+  url: https://grafana.com/api/dashboards/11314/revisions/10/download
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
@@ -90,9 +82,7 @@ spec:
       inputName: DS_PROMETHEUS
   folder: Unifi
   # renovate: depName="UniFi-Poller: USW Insights - Prometheus"
-  grafanaCom:
-    id: 11312
-    revision: 9
+  url: https://grafana.com/api/dashboards/11312/revisions/9/download
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
@@ -109,6 +99,4 @@ spec:
       inputName: DS_PROMETHEUS
   folder: Unifi
   # renovate: depName="UniFi-Poller: USG Insights - Prometheus"
-  grafanaCom:
-    id: 11313
-    revision: 9
+  url: https://grafana.com/api/dashboards/11313/revisions/9/download

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/grafanadashboard.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/grafanadashboard.yaml
@@ -13,7 +13,6 @@ spec:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   folder: Ceph
-  # renovate: depName="Ceph Cluster"
   url: https://grafana.com/api/dashboards/2842/revisions/18/download
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
@@ -30,7 +29,6 @@ spec:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   folder: Ceph
-  # renovate: depName="Ceph - OSD (Single)"
   url: https://grafana.com/api/dashboards/5336/revisions/9/download
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
@@ -47,5 +45,4 @@ spec:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
   folder: Ceph
-  # renovate: depName="Ceph - Pools"
   url: https://grafana.com/api/dashboards/5342/revisions/9/download

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/grafanadashboard.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/grafanadashboard.yaml
@@ -14,9 +14,7 @@ spec:
       inputName: DS_PROMETHEUS
   folder: Ceph
   # renovate: depName="Ceph Cluster"
-  grafanaCom:
-    id: 2842
-    revision: 18
+  url: https://grafana.com/api/dashboards/2842/revisions/18/download
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
@@ -33,9 +31,7 @@ spec:
       inputName: DS_PROMETHEUS
   folder: Ceph
   # renovate: depName="Ceph - OSD (Single)"
-  grafanaCom:
-    id: 5336
-    revision: 9
+  url: https://grafana.com/api/dashboards/5336/revisions/9/download
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
@@ -52,6 +48,4 @@ spec:
       inputName: DS_PROMETHEUS
   folder: Ceph
   # renovate: depName="Ceph - Pools"
-  grafanaCom:
-    id: 5342
-    revision: 9
+  url: https://grafana.com/api/dashboards/5342/revisions/9/download


### PR DESCRIPTION
Hermes first task. To rewrite all grafanaDashboard `gnetId` to `URL`