### PR TITLE
feat(hermes): authenticate gh from a scoped token on disk

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -64,6 +64,14 @@ spec:
               runAsUser: *uid
           03-install-tools:
             image: *img
+            env:
+              # ~/.config/gh is root-owned; this container is uid 10000 and could
+              # not write there. Also avoids setting HOME, which would move where
+              # brew and npm install below.
+              GH_CONFIG_DIR: &ghConfigDir /opt/data/.gh
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
             command:
               - /bin/sh
               - -c
@@ -98,6 +106,14 @@ spec:
                 if [ -f /opt/hermes/plugins/platforms/photon/sidecar/package.json ]; then
                   cd /opt/hermes/plugins/platforms/photon/sidecar && npm ci 2>/dev/null || npm install
                 fi
+
+                # The agent's shell never sees GITHUB_TOKEN, so gh needs it on
+                # disk. `env -u` is required — gh refuses --with-token while
+                # GITHUB_TOKEN is set. Re-runs each boot to pick up rotation.
+                if [ -n "$$GITHUB_TOKEN" ]; then
+                  printf '%s' "$$GITHUB_TOKEN" \
+                    | env -u GITHUB_TOKEN -u GH_TOKEN /opt/data/.local/bin/gh auth login --with-token
+                fi
             securityContext:
               allowPrivilegeEscalation: false
               capabilities: { drop: ["ALL"] }
@@ -117,17 +133,16 @@ spec:
               HOMEBREW_PREFIX: /opt/data/.local/homebrew
               HOMEBREW_REPOSITORY: /opt/data/.local/homebrew
               GATEWAY_ALLOW_ALL_USERS: true
+              # Must match 03-install-tools, or gh looks in the root-owned default.
+              GH_CONFIG_DIR: *ghConfigDir
               # No ~/.gitconfig on the PVC, so `git commit` has no identity and no signing
               # config. GIT_CONFIG_COUNT/KEY/VALUE supplies both without writing a file.
               GIT_AUTHOR_NAME: &gitUser hermes
               GIT_AUTHOR_EMAIL: &gitEmail 585808+tscibilia@users.noreply.github.com
               GIT_COMMITTER_NAME: *gitUser
               GIT_COMMITTER_EMAIL: *gitEmail
-              # Push auth. GITHUB_TOKEN is scrubbed from every shell the terminal
-              # tool spawns (_ALWAYS_STRIP_KEYS), so an env credential can never
-              # reach git. A key file can — this is the bundled github-auth
-              # skill's Option B. The same key both signs and authenticates; it
-              # is registered on the account twice, as Signing and as Auth.
+              # Push auth. GITHUB_TOKEN is scrubbed from every shell the terminal tool
+              # spawns (_ALWAYS_STRIP_KEYS), so an env credential can never reach git.
               GIT_SSH_COMMAND: ssh -i /opt/data/.ssh/hermes_signing -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new
               GIT_CONFIG_COUNT: "5"
               GIT_CONFIG_KEY_0: gpg.format


### PR DESCRIPTION
Creating a pull request is a REST call, so SSH cannot carry it, and the agent's
shell never sees GITHUB_TOKEN — _ALWAYS_STRIP_KEYS removes it from every
subprocess the terminal tool spawns. gh reads a credential file, so
03-install-tools writes one from the token already in the secret, re-running
each boot so a rotated token lands.

`env -u` is load-bearing: gh refuses --with-token while GITHUB_TOKEN is set in
its own environment, and without it the init container fails under set -e.

GH_CONFIG_DIR moves that credential to /opt/data/.gh. The default
~/.config/gh is root-owned on this volume and the init container runs as uid
10000, so it could not write there. Setting HOME instead would have worked for
gh but moved where brew and npm install in the same script. The app container
takes the same value through a YAML anchor so the two cannot drift.

This uses the scoped PAT rather than a device-flow login, which would mint a
broad account-wide OAuth token and undo the repository narrowing.
