### PR TITLE
fix(litellm): drop unsupported params on the zen-hosted models

### DIFF
--- a/kubernetes/apps/ai/litellm/app/litellmmodels.yaml
+++ b/kubernetes/apps/ai/litellm/app/litellmmodels.yaml
@@ -179,6 +179,8 @@ spec:
     apiKeyRef:
       name: litellm-secret
       key: OPENCODE_API_KEY
+    # Same Zen endpoint as deepseek-v4-flash-free — assumed same reasoning_effort issue.
+    dropParams: true
   info:
     mode: chat
     maxTokens: 131072
@@ -207,6 +209,8 @@ spec:
     apiKeyRef:
       name: litellm-secret
       key: OPENCODE_API_KEY
+    # Zen rejects reasoning_effort, despite supportting on models.dev; every call from hermes failed.
+    dropParams: true
   info:
     mode: chat
     maxTokens: 128000 # Non-free version supports 384000


### PR DESCRIPTION
hermes sends reasoning_effort on every request via agent.reasoning_effort, and
opencode.ai/zen rejects it with a 400 despite the models advertising
supports_reasoning. deepseek-v4-flash-free is the default model, so every turn
failed its first call and silently fell back to qwen-local — the local 27B has
been answering all along.

Only qwen-local and qwen-local-fast carried dropParams. Adding it to the two
models on that endpoint fixes the class of failure without touching glm-5-2,
minimax-m3 or laguna-s-2-1, which sit on different endpoints and have not
errored. A proxy-wide litellm drop_params would cover everything in one line but
would also mask genuinely wrong params everywhere.
