### PR TITLE
fix(litellm): drop unsupported params proxy-wide, not per model

### DIFF
--- a/kubernetes/apps/ai/litellm/app/litellmmodels.yaml
+++ b/kubernetes/apps/ai/litellm/app/litellmmodels.yaml
@@ -16,7 +16,6 @@ spec:
       # Keys under `additional` are copied into litellm_params VERBATIM
       # expects snake_case, operator only camelCases its own typed fields
       max_parallel_requests: 1
-    dropParams: true
   info:
     mode: chat
     maxTokens: 32768
@@ -51,13 +50,12 @@ spec:
       # expects snake_case, operator only camelCases its own typed fields
       max_parallel_requests: 1
       extra_body:
-        # drop_params strips reasoning_effort, but chat_template_kwargs reaches llama.cpp intact
+        # extra_body bypasses the proxy's drop_params, so this reaches llama.cpp intact
         chat_template_kwargs:
           enable_thinking: false
         temperature: 0.7
         top_p: 0.80
         presence_penalty: 1.5
-    dropParams: true
   info:
     mode: chat
     maxTokens: 32768
@@ -179,8 +177,6 @@ spec:
     apiKeyRef:
       name: litellm-secret
       key: OPENCODE_API_KEY
-    # Same Zen endpoint as deepseek-v4-flash-free — assumed same reasoning_effort issue.
-    dropParams: true
   info:
     mode: chat
     maxTokens: 131072
@@ -209,8 +205,6 @@ spec:
     apiKeyRef:
       name: litellm-secret
       key: OPENCODE_API_KEY
-    # Zen rejects reasoning_effort, despite supportting on models.dev; every call from hermes failed.
-    dropParams: true
   info:
     mode: chat
     maxTokens: 128000 # Non-free version supports 384000

--- a/kubernetes/apps/ai/litellm/app/litellmproxy.yaml
+++ b/kubernetes/apps/ai/litellm/app/litellmproxy.yaml
@@ -19,7 +19,9 @@ spec:
       type: redis
       host: os.environ/REDIS_HOST
       port: os.environ/REDIS_PORT
-    drop_params: false
+    # hermes sends reasoning_effort on every request; only qwen advertises it.
+    # Per-model dropParams lost — every non-qwen model 400s without this.
+    drop_params: true
     request_timeout: 600
     set_verbose: false
     require_auth_for_metrics_endpoint: false


### PR DESCRIPTION
hermes sets agent.reasoning_effort, so it sends reasoning_effort on every
request. Only qwen-local advertises the param, so every other model returned
litellm.UnsupportedParamsError. The per-model dropParams flags added in #3391
fixed deepseek-v4-flash-free and kimi-k3 but left minimax-m3, glm-5-2 and
laguna-s-2-1 broken — fallback #2, fallback #3 and the compression aux model.
Deepseek's 429 exposed it: the fallback ladder had no working rungs below
qwen-local.

Setting litellmSettings.drop_params once removes the whack-a-mole. The four
per-model flags are now redundant and go with it. additional.extra_body is
unaffected, which is why qwen-local-fast's chat_template_kwargs still reaches
llama.cpp — comment updated to say so.
