### PR TITLE
refactor(ai): give each model in hermes' chain a distinct failure mode

### DIFF
--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -20,20 +20,17 @@ data:
             context_length: 1048576
           deepseek-v4-flash-free:
             context_length: 200000
-          minimax-m3:
-            context_length: 512000
-          glm-5-2:
-            context_length: 1048560
+          deepseek-v4-flash:
+            context_length: 1048576
     model:
       default: deepseek-v4-flash-free
       provider: litellm
+    # Ordered by what each rung survives: a zen fault, then a WAN fault.
     fallback_providers:
       - provider: litellm
-        model: qwen-local
+        model: qwen-local # on-node, slow to warm
       - provider: litellm
-        model: minimax-m3
-      - provider: litellm
-        model: glm-5-2
+        model: deepseek-v4-flash
     # Side tasks. Default "auto" would reuse the main chat model for all of
     # them; pinning keeps the cheap/local models on the cheap work.
     auxiliary:
@@ -56,7 +53,7 @@ data:
         max_concurrency: 2
       compression:
         provider: custom:litellm
-        model: laguna-s-2-1 # 1M input window — the aux task that reads the most
+        model: laguna-s-2-1 # 1M input window, or deepseek-v4-flash as alt
         max_concurrency: 2
       moa_reference:
         provider: custom:litellm
@@ -90,7 +87,9 @@ data:
             - provider: custom:litellm
               model: qwen-local
             - provider: custom:litellm
-              model: minimax-m3
+              model: deepseek-v4-flash-free
+            - provider: custom:litellm
+              model: laguna-s-2-1
           aggregator:
             provider: custom:litellm
             model: kimi-k3

--- a/kubernetes/apps/ai/litellm/app/litellmmodels.yaml
+++ b/kubernetes/apps/ai/litellm/app/litellmmodels.yaml
@@ -112,11 +112,11 @@ spec:
 apiVersion: litellm.home-operations.com/v1alpha1
 kind: LiteLLMModel
 metadata:
-  name: &name glm-5-2
+  name: &name deepseek-v4-flash
 spec:
   modelName: *name
   params:
-    model: openai/glm-5.2
+    model: openai/deepseek/deepseek-v4-flash
     apiBase: https://openrouter.ai/api/v1
     apiKeyRef:
       name: litellm-secret
@@ -124,17 +124,21 @@ spec:
     additional:
       extra_body:
         provider:
+          # The cheapest host of this model; Zen ~3x this output cost and adds peak/off-peak pricing.
           order: ["deepinfra"]
           allow_fallbacks: false
   info:
     mode: chat
     maxTokens: 131072
-    maxInputTokens: 1048560
+    maxInputTokens: 1048576
     maxOutputTokens: 131072
     supportsFunctionCalling: true
     supportsPromptCaching: true
     extra:
       supports_reasoning: true
+      inputCostPerToken: 0.0000000800
+      cacheReadInputTokenCost: 0.0000000160
+      outputCostPerToken: 0.0000001800
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json
 apiVersion: litellm.home-operations.com/v1alpha1
@@ -145,6 +149,7 @@ spec:
   modelName: *name
   params:
     model: minimax/minimax-m3
+    # https://opencode.ai/docs/zen#pricing
     apiBase: https://opencode.ai/zen/v1
     apiKeyRef:
       name: litellm-secret
@@ -173,6 +178,7 @@ spec:
   modelName: *name
   params:
     model: openai/kimi-k3
+    # https://opencode.ai/docs/zen#pricing
     apiBase: https://opencode.ai/zen/v1
     apiKeyRef:
       name: litellm-secret
@@ -201,10 +207,15 @@ spec:
   modelName: *name
   params:
     model: openai/deepseek-v4-flash-free
+    # https://opencode.ai/docs/zen#pricing
     apiBase: https://opencode.ai/zen/v1
     apiKeyRef:
       name: litellm-secret
       key: OPENCODE_API_KEY
+    additional:
+      # Zen serves free models to its own client, all others gets 429 FreeUsageLimitError.
+      extra_headers:
+        User-Agent: opencode/1.0
   info:
     mode: chat
     maxTokens: 128000 # Non-free version supports 384000


### PR DESCRIPTION
glm-5-2 was strictly dominated by deepseek-v4-flash: worse at coding (59 vs 69) and agentic work (46 vs 48), 4.6x slower, and 17x/24x the input/output cost. Its only win was one point of Intelligence. Replaced with the paid twin of the model hermes already defaults to — same behaviour, 1M window instead of 200k, and hosted by DeepInfra via OpenRouter rather than zen.

That is the point of the swap. The old chain was default(zen) -> qwen-local -> minimax-m3(zen) -> glm-5-2(openrouter), so a zen fault took out two rungs and the ordering put the local model ahead of cheaper remote ones. The chain is now zen-free -> non-zen paid -> on-node, each rung surviving a fault the one above it does not.

minimax-m3 is dropped from hermes (it benchmarks below the free deepseek while costing money) but stays defined in litellm for direct use from opencode. laguna-s-2-1 keeps the compression slot. Nothing else moves.