### PR TITLE
fix(comfyui): mount /root/user-scripts so the entrypoint can start

### DIFF
--- a/kubernetes/apps/ai/comfyui/app/inferenceservice.yaml
+++ b/kubernetes/apps/ai/comfyui/app/inferenceservice.yaml
@@ -84,6 +84,10 @@ spec:
     - name: idle-probe
       configMap:
         name: comfyui-idle-probe
+    - name: user-scripts
+      # The entrypoint unconditionally creates this dir and seeds pre-start.sh
+      # into it; /root is not writable, so without a mount here it exits 1.
+      emptyDir: {}
     - name: tmp
       emptyDir: {}
     - name: dshm
@@ -128,6 +132,8 @@ spec:
       mountPath: /root/probe/idle-probe.py
       subPath: idle-probe.py
       readOnly: true
+    - name: user-scripts
+      mountPath: /root/user-scripts
     - name: tmp
       mountPath: /tmp
     - name: dshm


### PR DESCRIPTION
comfyui crash-looped on first wake: the image's entrypoint always creates
/root/user-scripts and seeds pre-start.sh into it, /root is not writable in
this pod, and the script runs under `set -e`, so it exited 1.

Mounting an emptyDir there makes the mkdir a no-op and gives the seed copy
writable space. Kubelet creates the mount point host-side, so it does not
depend on the container's own permissions — the same reason the bundle copy
into /root/ComfyUI already worked, since those subPath mounts had created
that path.
