### PR TITLE
fix(litellm): revert llama-qwen to llama.cpp b10454 to stop node-level OOM

### DIFF
--- a/kubernetes/apps/ai/litellm/app/llama-qwen.yaml
+++ b/kubernetes/apps/ai/litellm/app/llama-qwen.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   modelRef: llama-qwen
   runtime: llamacpp
-  image: ghcr.io/ggml-org/llama.cpp:server-cuda-b10481@sha256:b2497f8834f5ecb4e38530f6bf2734b8e0be107ff48e4720145911c86930f2ce
+  image: ghcr.io/ggml-org/llama.cpp:server-cuda-b10454@sha256:f0b55651b7398e34386ed7b8933d679f3fb6361e8de8429e489b84084ea950e7
   rolloutPolicy:
     waitForIdle: true
     idleTimeoutSeconds: 3600


### PR DESCRIPTION
## Why

`llama-qwen` on node `ai3090` is OOM-killed by the kernel (exit 137) under sustained load — 3 restarts since 2026-08-19.

Root cause: image bump to `server-cuda-b10481` (PR #3409, merged 2026-08-18) regressed host-RAM usage. With the identical config, llama-server's working set now plateaus at ~19.2GiB on a node with ~20.4GiB allocatable; node `MemAvailable` cratered to ~83MB before each kill (old b10454 era: min ~7GB free, zero restarts).

Evidence:
- Last 3 OOM kills at 2026-08-19 06:39Z / 08:09Z / 2026-08-20 02:09Z, all mid-generation (previous container logs), token gen slowing to ~0.3 t/s (RAM thrash)
- kube_pod_container_status_restarts_total: 0 → 3 only after the b10481 RS landed (08-18 12:33Z)
- node_memory_MemAvailable_bytes on ai3090 (192.168.5.214): ~83MB at kill, recovers to ~19.8GB after restart
- comfyui inactive during all three windows — the #3405 GPU-swap feature is not the trigger

## Change

Revert only `llama-qwen`'s image to `server-cuda-b10454@f0b5565` (the build that ran this exact Model/InferenceService config for days without OOM). memini embed/rerank vulkan builds (also bumped in #3409) left untouched — no crashes there.

## Note

- Renovate already has #3427 open bumping to `b10524` — worth testing separately; do not merge blind.
- Deeper issue: this config (`contextSize: 163840`, `--cache-ram 20480`, MTP draft) leaves ~1GiB headroom on a 24GB-RAM node. If OOMs return, cut `--cache-ram` and/or contextSize.