### PR TITLE
fix(filebrowser): track v2 beta channel on ghcr

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -19,10 +19,10 @@
       schedule: ["before 3am on Monday"],
     },
     {
-      description: "Track FileBrowser Quantum 2.x.x-preview-x only (v2 config layout is still moving; a silent jump to stable risks a config migration)",
+      description: "Track FileBrowser Quantum 2.x.x-beta only (v2 config layout is still moving; a silent jump to stable risks a config migration, and stable/latest still resolve to the v1 line)",
       matchDatasources: ["docker"],
-      matchPackageNames: ["docker.io/gtstef/filebrowser"],
-      versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-preview-(?<build>\\d+)$",
+      matchPackageNames: ["ghcr.io/gtsteffaniak/filebrowser"],
+      versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-beta$",
       allowedVersions: "/^2\\./",
     },
     {

--- a/kubernetes/apps/default/filebrowser/app/helmrelease.yaml
+++ b/kubernetes/apps/default/filebrowser/app/helmrelease.yaml
@@ -17,11 +17,11 @@ spec:
         containers:
           app:
             image:
-              # TODO: v2 is in preview. Renovate is pinned to 2.x.x-preview-x via a regex
-              # versioning rule in .renovate/overrides.json5 — GA tags will NOT match, so
-              # the move to stable is deliberate. Drop both when v2.0.0 ships.
-              repository: docker.io/gtstef/filebrowser
-              tag: 2.0.0-preview-5@sha256:858a60fc6e742f2d4e12669074d08b242e2e670e71414aba1597caad54ed22c4
+              # TODO: v2 is in beta. Renovate is pinned to 2.x.x-beta via a regex rule in
+              # .renovate/overrides.json5 — stable/latest still resolve to v1, so matching
+              # them would downgrade. Drop both when v2.0.0 GA ships.
+              repository: ghcr.io/gtsteffaniak/filebrowser
+              tag: 2.0.2-beta@sha256:50930d29da45eed1ebe0ecbb4a86ffd1947400c1d6d496f981351bdc505f0214
             env:
               FILEBROWSER_CONFIG: /config/config.yaml
             probes:


### PR DESCRIPTION
The docker.io/gtstef/filebrowser lookup was dead: FileBrowser Quantum
renamed its v2 pre-release channel from -preview-N to -beta after
2.0.0-preview-5, so the Renovate regex matched nothing and the dashboard
went silent. The pinned tag 2.0.2-beta-5 was also fabricated — a leftover
-5 from the old preview tag; only the digest was keeping the pod correct.

Move to ghcr.io/gtsteffaniak/filebrowser (same manifest digest, so no
image change), correct the tag to 2.0.2-beta, and retarget the versioning
regex at -beta. stable/latest still resolve to the v1 line, so the guard
against GA tags stays.
