### PR TITLE
Sonarr 4.0.19.3006 (develop, built 2026-08-24) added hostname validation and a trusted networks setting (Sonarr/Sonarr@5f69ab0954, Sonarr/Sonarr@22f05a4343). Both are currently unset, which leaves host filtering at wildcard and raises an `AllowedHostsCheck` health warning since auth is `DisabledForLocalAddresses`.

### DIFF
--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -26,7 +26,9 @@ spec:
               SONARR__AUTH__REQUIRED: DisabledForLocalAddresses
               SONARR__LOG__DBENABLED: "False"
               SONARR__LOG__LEVEL: info
+              SONARR__SERVER__ALLOWEDHOSTS: "sonarr.${SECRET_DOMAIN},sonarr.media.svc.cluster.local"
               SONARR__SERVER__PORT: &port 8989
+              SONARR__SERVER__TRUSTEDNETWORKS: 10.42.0.0/16
               SONARR__UPDATE__BRANCH: develop
             envFrom:
               - secretRef:
@@ -45,6 +47,9 @@ spec:
                   httpGet:
                     path: ${GATUS_PATH}
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
                   periodSeconds: 30
                   timeoutSeconds: 5
                   failureThreshold: 5


### PR DESCRIPTION
- `SONARR__SERVER__ALLOWEDHOSTS`: external hostname plus `sonarr.media.svc.cluster.local`, which is what prowlarr, recyclarr, and cleanrr all use. Loopback and the pod hostname are always allowed, covering the in-pod webhook scripts.
- `SONARR__SERVER__TRUSTEDNETWORKS`: pod CIDR, restoring trust of `X-Forwarded-For` from envoy; the upstream change dropped the previously hardcoded RFC1918 trust so client IPs were logging as the envoy pod IP.
- Readiness probe sends `Host: localhost`; the kubelet otherwise uses the pod IP as the Host header, which host filtering rejects. Liveness and startup probes are TCP and unaffected.
