### PR TITLE
feat(cleanrr): add cleanrr to media namespace

### DIFF
--- a/docs/context/apps.md
+++ b/docs/context/apps.md
@@ -103,6 +103,7 @@ Full list by namespace. The source of truth is `kubernetes/apps/`; the list belo
 - agregarr _(home media aggregator dashboard)_ [kopiur]
 - autobrr _(torrent automation)_ [kopiur, zeroscaler, oidc]
 - bazarr _(subtitles)_ [kopiur, auth, zeroscaler]
+- cleanrr
 - flaresolverr _(solves cloudflare captcha)_
 - hometube _(yt-dlp UI)_ [kopiur, auth, zeroscaler]
 - imagemaid _(Plex image cleanup)_

--- a/kubernetes/apps/media/cleanrr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/cleanrr/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name cleanrr-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless-secret-store
+  target:
+    name: *name
+    template:
+      data:
+        CLEANRR_SERVERS__RADARR__API_KEY: "{{ .RADARR_API_KEY }}"
+        CLEANRR_SERVERS__SONARR__API_KEY: "{{ .SONARR_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: /media/arr-apps

--- a/kubernetes/apps/media/cleanrr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/cleanrr/app/helmrelease.yaml
@@ -1,0 +1,90 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app cleanrr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    controllers:
+      *app :
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/zariel/cleanrr
+              tag: v0.1.6@sha256:ff5de090d4295a56cedd8c8167d0e5b070970d3ca304090d36001c922fc8a2d0
+            env:
+              CLEANRR_DRY_RUN: true
+              CLEANRR_MINIMUM_AGE: 30m
+              CLEANRR_POLL_INTERVAL: 2m
+              CLEANRR_SERVERS__RADARR__URL: http://radarr.media.svc.cluster.local:7878
+              CLEANRR_SERVERS__SONARR__URL: http://sonarr.media.svc.cluster.local:8989
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec: &probeSpec
+                  httpGet:
+                    path: /health/live
+                    port: &port 8080
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                <<: *probes
+                spec:
+                  <<: *probeSpec
+                  httpGet:
+                    path: /health/ready
+                    port: *port
+                  periodSeconds: 10
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health/startup
+                    port: *port
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+              readOnlyRootFilesystem: true
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: *port
+    serviceMonitor:
+      app:
+        endpoints:
+          - port: http
+            path: /metrics
+            interval: 1m
+            scrapeTimeout: 10s

--- a/kubernetes/apps/media/cleanrr/app/kustomization.yaml
+++ b/kubernetes/apps/media/cleanrr/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/media/cleanrr/app/ocirepository.yaml
+++ b/kubernetes/apps/media/cleanrr/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cleanrr
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/media/cleanrr/ks.yaml
+++ b/kubernetes/apps/media/cleanrr/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cleanrr
+spec:
+  dependsOn:
+    - name: secret-stores
+      namespace: external-secrets
+    - name: radarr
+    - name: sonarr
+  interval: 1h
+  path: ./kubernetes/apps/media/cleanrr/app
+  postBuild:
+    substitute:
+      APP: *app
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: media
+  wait: false

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./agregarr/ks.yaml
   - ./autobrr/ks.yaml
   - ./bazarr/ks.yaml
+  - ./cleanrr/ks.yaml
   - ./flaresolverr/ks.yaml
   - ./hometube/ks.yaml
   - ./imagemaid/ks.yaml


### PR DESCRIPTION
Removes stale importBlocked items from the Radarr and Sonarr queues.
Ported from onedr0p/home-ops#11566, adapted to the media namespace,
native container ports and the /media/arr-apps aKeyless path.

Starts in dry-run: it logs candidates only. Flip CLEANRR_DRY_RUN to
false after reviewing the logs.
