### PR TITLE
fix(renovate): constrain prompp to 0.x

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -39,6 +39,12 @@
       allowedVersions: "/^0\\./",
     },
     {
+      description: "Constrain prompp to 0.x (3.8.x is the same manifest digest as 0.8.x)",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["ghcr.io/deckhouse/prompp"],
+      allowedVersions: "/^0\\./",
+    },
+    {
       description: "Resolve Immich from GitHub releases (paging 40k+ GHCR tags intermittently 429s, failing the lookup)",
       matchDatasources: ["docker"],
       matchPackageNames: [


### PR DESCRIPTION
3.8.14 is a stray GHCR tag, not a release. Its manifest digest is
identical to 0.8.10 (sha256:49e4375...), both built from commit
8d8117ce ("release(v0.8.10)"). No v3.8.14 git tag or GitHub release
exists in deckhouse/prompp.
