### PR TITLE
feat(rook-ceph): rotate cephx daemon keys and drop stale PrometheusRule patch

### DIFF
--- a/docs/context/storage.md
+++ b/docs/context/storage.md
@@ -3,6 +3,7 @@
 ## ⚠️ Gotchas & Interactions
 
 - **CNPG endpoints are named after the cluster, not the app:** the `host` key is `{cluster}-rw.database.svc.cluster.local` — `pgsql-cluster-rw` or `pgvector-cluster-rw`, shared by every app on that cluster. Use the `host` key from `${APP}-pguser-secret` rather than composing a name. Never point an app at `-ro`; that is the read replica.
+- **Ceph mutes four `AUTH_INSECURE_*` warnings on purpose:** Ceph Tentacle (v20) flags the older `aes` cephx cipher. Daemon keys (mon/mgr/osd) are rotated to `aes256k` via `security.cephx.daemon`, but CSI keys are pinned to `aes` because `aes256k` needs a host kernel of 7.0+ and the Talos nodes are below that. The remaining warnings cannot clear, so they are muted declaratively in `cephClusterSpec.healthCheck.muteHealthWarning`. Unmute — and drop `security.cephx.csi.keyType` — once the nodes reach kernel 7.0+.
 - **openebs-hostpath is node-local:** Data is tied to the node. A pod rescheduling to a different node loses access to its PVC.
 
 ## Storage Classes

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -9,17 +9,7 @@ spec:
     kind: OCIRepository
     name: *app
   interval: 1h
-  # Resolve ceph 1.19.6 issue with `ceph_pool_metadata` having duplicate label combinations
-  postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              kind: PrometheusRule
-              name: prometheus-ceph-rules
-            patch: |
-              - op: replace
-                path: /spec/groups/7/rules/0/expr
-                value: "(max by (cluster, pool_id) (predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5)) * on(cluster, pool_id) group_right(name, application) max by (cluster, pool_id, name, application) (ceph_pool_metadata)) >= 95"
+  timeout: 10m
   dependsOn:
     - name: snapshot-controller
       namespace: kube-system
@@ -44,6 +34,15 @@ spec:
         ssl: false
         prometheusEndpoint: http://prometheus-operated.observability.svc.cluster.local:9090
       healthCheck:
+        # CSI keys are pinned to aes below, so these four can never clear on their
+        # own. Unmute once nodes reach kernel 7.0+ and CSI moves to aes256k.
+        muteHealthWarning:
+          AUTH_INSECURE_CLIENT_KEY_TYPE: &mute
+            policy: mute
+          AUTH_INSECURE_KEYS_ALLOWED: *mute
+          AUTH_INSECURE_KEYS_CREATABLE: *mute
+          # Surfaces transiently for 2-3h after daemon keys rotate.
+          AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE: *mute
         daemonHealth:
           mon:
             disabled: false
@@ -65,6 +64,14 @@ spec:
         osd:
           limits:
             memory: 8Gi
+      security:
+        cephx:
+          # One-shot rotation: bump keyGeneration again to rotate a second time.
+          daemon:
+            keyRotationPolicy: KeyGeneration
+            keyGeneration: 2
+          csi:
+            keyType: aes # aes256k needs kernel 7.0+; nodes are on 6.18
       storage:
         config:
           osdsPerDevice: "1"


### PR DESCRIPTION
Ceph Tentacle flags the older aes cephx cipher. Rotate daemon keys
(mon/mgr/osd) to aes256k via security.cephx.daemon, clearing the
AUTH_INSECURE_SERVICE_KEY_TYPE error.

Pin CSI keys to aes: aes256k requires host kernel 7.0+ and the Talos
nodes run 6.18. The four warnings that cannot clear as a result are
muted declaratively via healthCheck.muteHealthWarning.

Drop the postRenderers patch on CephPoolGrowthWarning. The v1.20 chart
aggregates both sides of the join, so the ceph_pool_metadata duplicate
label error is no longer possible. The patch was also erasing the name
label -- its group_right(name, application) copied those labels from a
left side that had neither -- leaving the alert reading "Pool '' will be
full". Verified against live Prometheus.

Add timeout: 10m so the rolling daemon restart this triggers does not
strand the HelmRelease in a rollback loop.

Ref: rook/rook cephx-key-rotation guide, onedr0p/home-ops#11552
