### PR TITLE
fix(cnpg): use ImageCatalog for timescaledb image

### DIFF
--- a/kubernetes/apps/database/cnpg/pgcluster-timescale/cluster.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-timescale/cluster.yaml
@@ -8,7 +8,11 @@ metadata:
     cnpg.io/skipEmptyWalArchiveCheck: "enabled"
 spec:
   instances: 3
-  imageName: timescale/timescaledb-ha:pg18.4-ts2.29.2@sha256:4e576b8c339fa3413c6a6aa9cd22953b42ecf4b13f4efedacb97ce8bd1b43b30
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ImageCatalog
+    name: timescaledb
+    major: 18
   primaryUpdateStrategy: unsupervised
   primaryUpdateMethod: switchover
   postgresGID: 1000

--- a/kubernetes/apps/database/cnpg/pgcluster-timescale/imagecatalog.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-timescale/imagecatalog.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/imagecatalog_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ImageCatalog
+metadata:
+  name: timescaledb
+spec:
+  # Catalog images skip the operator's tag-parsing check; timescale tags
+  # (pg18.4-ts2.29.2) are not a valid CNPG version tag.
+  images:
+    - major: 18
+      image: timescale/timescaledb-ha:pg18.4-ts2.29.2@sha256:4e576b8c339fa3413c6a6aa9cd22953b42ecf4b13f4efedacb97ce8bd1b43b30

--- a/kubernetes/apps/database/cnpg/pgcluster-timescale/kustomization.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-timescale/kustomization.yaml
@@ -4,5 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./cluster.yaml
+  - ./imagecatalog.yaml
   - ./scheduledbackup.yaml
   - ./service.yaml


### PR DESCRIPTION
CNPG auto-detects the Postgres major version from the image tag. The
timescale tag `pg18.4-ts2.29.2` does not start with a version number, so
the vcluster.cnpg.io webhook rejected the Cluster. Catalog images skip
that check, so move the pinned image into an ImageCatalog and reference
it with imageCatalogRef.
