### PR TITLE
fix(cnpg): swap orphaned immich17 ObjectStore for pgcluster-timescale

### DIFF
--- a/kubernetes/apps/database/cnpg/barman-cloud/objectstore.yaml
+++ b/kubernetes/apps/database/cnpg/barman-cloud/objectstore.yaml
@@ -26,7 +26,7 @@ spec:
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
-  name: immich17
+  name: pgcluster-timescale
 spec:
   retentionPolicy: 7d
   configuration:


### PR DESCRIPTION
The cluster's barman-cloud plugin points at barmanObjectName
pgcluster-timescale, but no ObjectStore of that name existed, so the
plugin's pre-reconcile hook stopped the loop on every pass and the
cluster never bootstrapped. immich17 has no Cluster left (immich runs
on pgvector-cluster), so its ObjectStore was dead weight.
