### PR TITLE
feat(tracearr): move to timescaledb cluster

### DIFF
--- a/kubernetes/apps/media/tracearr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/tracearr/app/externalsecret.yaml
@@ -19,8 +19,8 @@ spec:
         INIT_POSTGRES_DBNAME: "${APP}"
         INIT_POSTGRES_USER: "${APP}"
         INIT_POSTGRES_PASS: "{{ .${APP}_postgres_password }}"
-        INIT_POSTGRES_HOST: "${CNPG_NAME:=pgsql-cluster}-rw.database.svc.cluster.local"
-        DATABASE_URL: "postgres://${APP}:{{ .${APP}_postgres_password }}@${CNPG_NAME:=pgsql-cluster}-rw.database.svc.cluster.local:5432/${APP}"
+        INIT_POSTGRES_HOST: "${CNPG_NAME:=pgcluster-timescale}-rw.database.svc.cluster.local"
+        DATABASE_URL: "postgres://${APP}:{{ .${APP}_postgres_password }}@${CNPG_NAME:=pgcluster-timescale}-rw.database.svc.cluster.local:5432/${APP}"
   dataFrom:
     - extract:
         key: /media/tracearr

--- a/kubernetes/apps/media/tracearr/ks.yaml
+++ b/kubernetes/apps/media/tracearr/ks.yaml
@@ -10,7 +10,7 @@ spec:
   dependsOn:
     - name: secret-stores
       namespace: external-secrets
-    - name: cnpg-cluster
+    - name: cnpg-pgcluster-timescale
       namespace: database
     - name: dragonfly-cluster
       namespace: database
@@ -20,7 +20,7 @@ spec:
     substitute:
       APP: *app
       GATUS_PATH: /health
-      CNPG_NAME: &postgresAppName pgsql-cluster
+      CNPG_NAME: &postgresAppName pgcluster-timescale
     substituteFrom:
       - kind: Secret
         name: cluster-secrets


### PR DESCRIPTION
tracearr 2.1.0 needs TimescaleDB. Point the app and its initdb
secret at pgcluster-timescale instead of pgsql-cluster, and switch
the Flux dependsOn to the new cnpg-pgcluster-timescale Kustomization.
