### PR TITLE
fix(cnpg): raise max_locks_per_transaction for timescale

### DIFF
--- a/kubernetes/apps/database/cnpg/pgcluster-timescale/cluster.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-timescale/cluster.yaml
@@ -44,6 +44,8 @@ spec:
     parameters:
       max_connections: "200"
       shared_buffers: 256MB
+      # drop_chunks locks all ~4.2k library_snapshots chunks plus indexes in one transaction
+      max_locks_per_transaction: "512"
     pg_hba: ["host all all 10.42.0.0/16 scram-sha-256"]
     shared_preload_libraries: ["timescaledb"]
   resources:


### PR DESCRIPTION
tracearr's maintenance job calls drop_chunks on library_snapshots,
which locks every chunk plus its 3 indexes in one transaction. That
table uses 1-day chunks over a ~12 year span (~4.2k chunks), needing
~17k locks. The default 64 sized the shared lock table at 12.8k, so
the job failed every run with "out of shared memory" (SQLSTATE 53200).
