### PR TITLE
fix(ci): allow pr-reviewer gh_api to read upstream repos

### DIFF
--- a/.github/workflows/pr-reviewer.yaml
+++ b/.github/workflows/pr-reviewer.yaml
@@ -168,7 +168,7 @@ jobs:
           tool_planning_timeout_sec: "120"
           tool_planning_max_context_bytes: "100000"
           tool_planning_max_tokens: "32000"
-          tool_allowed_gh_api_repos: "tscibilia/home-ops"
+          tool_allowed_gh_api_repos: "*"
           tool_enable_for_forks: "false"
           tool_mcp_servers: "tools=http://litellm.ai.svc.cluster.local:4000/mcp/,konflate=http://konflate.flux-system.svc.cluster.local:8080/mcp"
           tool_mcp_token: ${{ steps.load-secrets.outputs.LITELLM_API_KEY }}


### PR DESCRIPTION
The reviewer could only GET api.github.com for tscibilia/home-ops, so
Renovate PRs pointing at an upstream (e.g. ggml-org/llama.cpp/releases)
were blocked before reading release notes. gh_api is GET-only and
path-restricted, and GITHUB_TOKEN carries no rights outside this repo,
so the wildcard widens which repo it may read, not what it may do.
