### PR TITLE
fix(tracearr): pin pg backup image to 18 for timescale cluster

### DIFF
--- a/kubernetes/apps/media/tracearr/ks.yaml
+++ b/kubernetes/apps/media/tracearr/ks.yaml
@@ -21,6 +21,7 @@ spec:
       APP: *app
       GATUS_PATH: /health
       CNPG_NAME: &postgresAppName pgcluster-timescale
+      PG_VER: "18"
     substituteFrom:
       - kind: Secret
         name: cluster-secrets


### PR DESCRIPTION
pgcluster-timescale runs PostgreSQL 18. The cnpg component defaults
PG_VER to 17, so pg_dump 17 refused the v18 server and every 4-hour
