### PR TITLE
feat(media): add airwave

### DIFF
--- a/docs/context/apps.md
+++ b/docs/context/apps.md
@@ -101,6 +101,7 @@ Full list by namespace. The source of truth is `kubernetes/apps/`; the list belo
 ## media
 
 - agregarr _(home media aggregator dashboard)_ [kopiur]
+- airwave [cnpg]
 - autobrr _(torrent automation)_ [kopiur, zeroscaler, oidc]
 - bazarr _(subtitles)_ [kopiur, auth, zeroscaler]
 - cleanrr

--- a/docs/context/components.md
+++ b/docs/context/components.md
@@ -227,6 +227,8 @@ Every namespace. Creates a Flux `Provider` pointing at `alertmanager-operated.ob
 
 Every namespace. Creates the `cluster-secrets` ExternalSecret, which is what makes `substituteFrom: cluster-secrets` resolve in that namespace. Keys: `SECRET_DOMAIN`, `CEAPP_DOMAIN`, `TIMEZONE`, `TAILSCALE_MAGICDNS`, `KOPIA_BUCKET`, drawn from three aKeyless paths (`/kubernetes/cluster-secrets`, `/network/tailscale/operator`, `/cloud-providers/b2-creds`). See `secrets.md`.
 
+The same file also declares the `password10` / `password32` / `password64` `Password` generator CRs. Being namespace-scoped, they only exist where this component is applied — which is why an app references one by name rather than declaring its own. See `secrets.md`.
+
 ### kopiur/secret — the Kopia repository password
 
 Only namespaces containing kopiur-backed apps. Creates `kopiur-nas-secret` (`KOPIA_PASSWORD`) so the movers in that namespace can open the repository.

--- a/docs/context/secrets.md
+++ b/docs/context/secrets.md
@@ -72,13 +72,36 @@ spec:
 
 Only consume `/security/pocket-id-clients` with an ExternalSecret when a _different_ app needs another app's client credentials — e.g. `kite`, whose config template renders them into a config file.
 
+## Password generators
+
+`components/secrets/externalsecret.yaml` also defines three `Password` generator CRs — `password10`, `password32`, `password64`. Because that component is applied in every namespace, all three exist everywhere and are referenced by name, never redeclared per app. All use `symbols: 0`: generated values get interpolated raw into URIs (`postgresql://`, `redis://`) where a symbol would need percent-encoding.
+
+An app seeds a credential by adding a generator entry to its own ExternalSecret's `dataFrom`, with `refreshInterval: "0"` on the spec:
+
+```yaml
+spec:
+    refreshInterval: "0" # the generator is stateless — this is the ONLY thing pinning the value
+    dataFrom:
+        - sourceRef:
+              generatorRef:
+                  apiVersion: generators.external-secrets.io/v1alpha1
+                  kind: Password
+                  name: password32
+```
+
+### Seeded CNPG passwords
+
+To avoid creating a CNPG role password by hand, pair the generator with a `PushSecret` that writes it to aKeyless. Two objects in the app's `app/` directory, both named `${APP}-pgpass` (see `media/airwave`): the generating ExternalSecret above, and a `PushSecret` with `updatePolicy: IfNotExists` targeting `/database/cnpg-users`, property `${APP}_postgres_password`.
+
+`IfNotExists` is what makes this safe to leave running: after the first write aKeyless is authoritative, and a regenerated local password can never overwrite the stored one. Everything else — `components/cnpg` and the app's own ExternalSecret — keeps reading `/database/cnpg-users` as usual, so on a first deploy those reads fail until the push lands, then recover.
+
 ## aKeyless Path Conventions
 
 | Path pattern                     | Contents                                                                                                                                                                               |
 | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/kubernetes/cluster-secrets`    | Cluster-wide vars (domain, timezone)                                                                                                                                                   |
 | `/{namespace}/{app-name}`        | App-specific secrets (e.g. `/ai/memini`, `/default/open-webui`)                                                                                                                        |
-| `/database/cnpg-users`           | CNPG user passwords (all apps share one secret, fields per-app)                                                                                                                        |
+| `/database/cnpg-users`           | CNPG user passwords (all apps share one secret, fields per-app). May be seeded by a generator + `PushSecret` — see "Seeded CNPG passwords" above.                                      |
 | `/security/pocket-id-clients`    | OIDC client credentials, `{APP}_OIDC_CLIENT_ID` / `{APP}_OIDC_CLIENT_SECRET` per app. **Written by `PushSecret`, not read by hand** — see "OIDC credentials" above.                    |
 | `/cloud-providers/b2-creds`      | Backblaze B2 (Kopiur bucket)                                                                                                                                                           |
 | `/cloud-providers/ai-apis`       | Third-party AI API keys (e.g. `FIRECRAWL_API_KEY`, used by hermes web_extract)                                                                                                         |

--- a/kubernetes/apps/media/airwave/app/externalsecret.yaml
+++ b/kubernetes/apps/media/airwave/app/externalsecret.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name airwave-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless-secret-store
+  target:
+    name: *name
+    template:
+      data:
+        DATABASE_URL: "postgresql://${APP}:{{ .${APP}_postgres_password }}@${CNPG_NAME:=pgsql-cluster}-rw.database.svc.cluster.local:5432/${APP}?schema=public"
+        BETTER_AUTH_SECRET: "{{ .BETTER_AUTH_SECRET }}"
+        ADMIN_EMAIL: "{{ .ADMIN_EMAIL }}"
+        ADMIN_PASSWORD: "{{ .ADMIN_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: /media/airwave
+    - extract:
+        key: /database/cnpg-users
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name "${APP}-pgpass"
+spec:
+  # Seeds the CNPG role password so it never has to be created by hand. The
+  # generator is stateless, so refreshInterval "0" is what pins the value.
+  refreshInterval: "0"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless-secret-store
+  target:
+    name: *name
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: password32

--- a/kubernetes/apps/media/airwave/app/helmrelease.yaml
+++ b/kubernetes/apps/media/airwave/app/helmrelease.yaml
@@ -1,0 +1,216 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app airwave
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    controllers:
+      server:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          01-init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18.6.0@sha256:b6d3af974df781c673d37e49bdddfa14a6f5be28b18d2cb7713f0449bea4057b
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-initdb-secret"
+        containers:
+          app:
+            image: &image
+              repository: ghcr.io/quixomatic/airwave
+              tag: 0.12.28@sha256:bc8b79f344e2cae9d0226cc2d48b18d4c4f045bb9ca9b231703fc1b3e3fbcb3a
+            env:
+              CG_ROLE: server
+              PORT: &serverPort 3000
+              BETTER_AUTH_URL: &serverUrl https://${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}
+              CORS_ORIGIN: https://${GATUS_SUBDOMAIN}-admin.${SECRET_DOMAIN}
+              TV_APP_ORIGIN: https://${GATUS_SUBDOMAIN}web.${SECRET_DOMAIN}
+              BUMPER_MUSIC_DIR: &bumperDir /data/bumper-music
+              PUID: &puid 1000
+              PGID: &pgid 1000
+              UMASK: &umask "022"
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            resources:
+              requests:
+                cpu: 20m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec: &probeSpec
+                  httpGet:
+                    path: /api/health
+                    port: *serverPort
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                <<: *probes
+                spec:
+                  <<: *probeSpec
+                  periodSeconds: 10
+              startup: &startupProbe
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: [ALL] }
+      web:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image: *image
+            env:
+              CG_ROLE: web
+              WEB_PORT: &webPort 3001
+              VITE_SERVER_URL: *serverUrl
+              PUID: *puid
+              PGID: *pgid
+              UMASK: *umask
+            resources:
+              requests:
+                cpu: 20m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+            probes:
+              liveness:
+                <<: *probes
+                spec:
+                  <<: *probeSpec
+                  httpGet:
+                    path: &healthPath /
+                    port: *webPort
+              readiness:
+                <<: *probes
+                spec:
+                  <<: *probeSpec
+                  periodSeconds: 10
+                  httpGet:
+                    path: *healthPath
+                    port: *webPort
+              startup: *startupProbe
+            securityContext: &buildSecurityContext
+              allowPrivilegeEscalation: false
+              # vite writes its build output inside the image at startup.
+              readOnlyRootFilesystem: false
+              capabilities: { drop: [ALL] }
+      tvweb:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image: *image
+            env:
+              CG_ROLE: tvweb
+              TV_WEB_PORT: &tvwebPort 3002
+              VITE_SERVER_URL: *serverUrl
+              PUID: *puid
+              PGID: *pgid
+              UMASK: *umask
+            resources:
+              requests:
+                cpu: 20m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+            probes:
+              liveness:
+                <<: *probes
+                spec:
+                  <<: *probeSpec
+                  httpGet:
+                    path: *healthPath
+                    port: *tvwebPort
+              readiness:
+                <<: *probes
+                spec:
+                  <<: *probeSpec
+                  periodSeconds: 10
+                  httpGet:
+                    path: *healthPath
+                    port: *tvwebPort
+              startup: *startupProbe
+            securityContext: *buildSecurityContext
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: *puid
+        runAsGroup: *pgid
+        fsGroup: *pgid
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      server:
+        controller: server
+        ports:
+          http:
+            port: *serverPort
+      web:
+        controller: web
+        ports:
+          http:
+            port: *webPort
+      tvweb:
+        controller: tvweb
+        ports:
+          http:
+            port: *tvwebPort
+    route:
+      server:
+        hostnames: ["${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: server
+                port: *serverPort
+      web:
+        hostnames: ["${GATUS_SUBDOMAIN}-admin.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: web
+                port: *webPort
+      tvweb:
+        hostnames: ["${GATUS_SUBDOMAIN}web.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: tvweb
+                port: *tvwebPort
+    persistence:
+      # emptyDir: uploaded bumper tracks are lost on restart. Swap for NFS or PVC
+      bumper-music:
+        type: emptyDir
+        advancedMounts:
+          server:
+            app:
+              - path: *bumperDir
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          server:
+            app:
+              - path: /tmp

--- a/kubernetes/apps/media/airwave/app/kustomization.yaml
+++ b/kubernetes/apps/media/airwave/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./pushsecret.yaml

--- a/kubernetes/apps/media/airwave/app/ocirepository.yaml
+++ b/kubernetes/apps/media/airwave/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: &app airwave
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/media/airwave/app/pushsecret.yaml
+++ b/kubernetes/apps/media/airwave/app/pushsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/pushsecret_v1alpha1.json
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: &name "${APP}-pgpass"
+spec:
+  refreshInterval: 1h
+  # IfNotExists makes aKeyless the source of truth after the first write
+  updatePolicy: IfNotExists
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: akeyless-secret-store
+  selector:
+    secret:
+      name: *name
+  data:
+    - match:
+        secretKey: password
+        remoteRef:
+          remoteKey: /database/cnpg-users
+          property: ${APP}_postgres_password

--- a/kubernetes/apps/media/airwave/ks.yaml
+++ b/kubernetes/apps/media/airwave/ks.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app airwave
+spec:
+  components:
+    - ../../../../components/cnpg
+  dependsOn:
+    - name: secret-stores
+      namespace: external-secrets
+    - name: cnpg-cluster
+      namespace: database
+  interval: 1h
+  path: ./kubernetes/apps/media/airwave/app
+  postBuild:
+    substitute:
+      APP: *app
+      GATUS_SUBDOMAIN: tv
+      CNPG_NAME: &postgresAppName pgsql-cluster
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  healthChecks:
+    - apiVersion: &postgresVersion postgresql.cnpg.io/v1
+      kind: &postgresKind Cluster
+      name: *postgresAppName
+      namespace: database
+  healthCheckExprs:
+    - apiVersion: *postgresVersion
+      kind: *postgresKind
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: media
+  wait: false

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -10,6 +10,7 @@ components:
 resources:
   - ./namespace.yaml
   - ./agregarr/ks.yaml
+  - ./airwave/ks.yaml
   - ./autobrr/ks.yaml
   - ./bazarr/ks.yaml
   - ./cleanrr/ks.yaml

--- a/kubernetes/components/cnpg/README.md
+++ b/kubernetes/components/cnpg/README.md
@@ -1,6 +1,48 @@
 ## CloudNative PG
 
-### Populate Secrets for new App
+This component adds three things to an app: `${APP}-initdb-secret` (consumed by the `postgres-init` init container), `${APP}-pguser-secret` (host/user/password/uri/dsn), and a `${APP}-pg-backups` CronJob. All of it reads the role password from aKeyless `/database/cnpg-users`, field `${APP}_postgres_password`.
+
+`${CNPG_NAME:=pgsql-cluster}` comes from each app's `ks.yaml` `postBuild.substitute`.
+
+### Getting the password into aKeyless
+
+Two ways. Both end with the same field in the same place — this component never changes.
+
+**Seeded (preferred for new apps).** ESO generates the password and pushes it. Nothing to run by hand. Two objects in the app's `app/`, both named `${APP}-pgpass` — see `apps/media/airwave/app/`:
+
+```yaml
+# externalsecret.yaml — a second document alongside the app's own secret
+metadata:
+    name: &name "${APP}-pgpass"
+spec:
+    refreshInterval: "0" # the generator is stateless — this is the ONLY thing pinning the value
+    target: { name: *name }
+    dataFrom:
+        - sourceRef:
+              generatorRef:
+                  apiVersion: generators.external-secrets.io/v1alpha1
+                  kind: Password
+                  name: password32 # declared in components/secrets, exists in every namespace
+```
+
+```yaml
+# pushsecret.yaml
+spec:
+    updatePolicy: IfNotExists
+    selector: { secret: { name: "${APP}-pgpass" } }
+    data:
+        - match:
+              secretKey: password
+              remoteRef:
+                  remoteKey: /database/cnpg-users
+                  property: ${APP}_postgres_password
+```
+
+`updatePolicy: IfNotExists` is load-bearing, and it is checked **per property**, not per key — so it writes `${APP}_postgres_password` even though `/database/cnpg-users` already exists, and after that first write aKeyless is authoritative. A regenerated local password can never overwrite the stored one. The push also merges: only its own property is touched.
+
+⚠️ On a first deploy this component's two ExternalSecrets reconcile before the push lands and report `SecretSyncedError` for a few seconds. That is the expected gap, not a fault — ESO templates with `missingkey=error`, so they write nothing rather than an empty password, then retry and succeed.
+
+**Manual.** Still correct, and what every pre-existing app uses:
 
 ```
 export APP=mealie
@@ -10,5 +52,3 @@ akeyless update-secret-val \
   --custom-field "${APP}_postgres_username=${APP}" \
   --custom-field "${APP}_postgres_password=${PASSWORD}"
 ```
-
-`${CNPG_NAME:=pgsql-cluster}` comes from each app's ks.yaml postBuild > substitute schema

--- a/kubernetes/components/secrets/externalsecret.yaml
+++ b/kubernetes/components/secrets/externalsecret.yaml
@@ -24,3 +24,36 @@ spec:
         key: /network/tailscale/operator
     - extract:
         key: /cloud-providers/b2-creds
+---
+# Reusable password generators, one per length. An app references one from
+# `dataFrom.sourceRef.generatorRef` to seed a credential instead of a manual task.
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/generators.external-secrets.io/password_v1alpha1.json
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: password10
+spec:
+  length: 10
+  allowRepeat: true
+  noUpper: false
+  symbols: 0
+---
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: password32
+spec:
+  length: 32
+  allowRepeat: true
+  noUpper: false
+  symbols: 0
+---
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: password64
+spec:
+  length: 64
+  allowRepeat: true
+  noUpper: false
+  symbols: 0


### PR DESCRIPTION
Three-role deploy from one image (CG_ROLE): server API on
envoy-external, admin web and TV player on envoy-internal.
CNPG-backed.

The CNPG role password is seeded rather than created by hand: a
shared Password generator (new in components/secrets, applied in
every namespace) fills airwave-pgpass, and a PushSecret with
updatePolicy IfNotExists writes it to /database/cnpg-users. After
that first write aKeyless is authoritative, so a regenerated local
password can never overwrite it, and components/cnpg keeps reading
aKeyless unchanged.

DATABASE_URL is assembled in the ExternalSecret rather than from
POSTGRES_* because CNPG owns the credentials. web and tvweb run a
vite build at startup, so they cannot use a read-only root
filesystem.
