### PR TITLE
fix(media): run airwave containers as root per its entrypoint

### DIFF
--- a/kubernetes/apps/media/airwave/app/helmrelease.yaml
+++ b/kubernetes/apps/media/airwave/app/helmrelease.yaml
@@ -68,11 +68,6 @@ spec:
                 spec:
                   failureThreshold: 30
                   periodSeconds: 10
-            securityContext:
-              allowPrivilegeEscalation: false
-              # entrypoint rewrites /etc at start (localtime link, timezone, usermod)
-              readOnlyRootFilesystem: false
-              capabilities: { drop: [ALL] }
       web:
         annotations:
           reloader.stakater.com/auto: "true"
@@ -110,11 +105,6 @@ spec:
                     path: *healthPath
                     port: *webPort
               startup: *startupProbe
-            securityContext: &buildSecurityContext
-              allowPrivilegeEscalation: false
-              # vite writes its build output inside the image at startup.
-              readOnlyRootFilesystem: false
-              capabilities: { drop: [ALL] }
       tvweb:
         annotations:
           reloader.stakater.com/auto: "true"
@@ -152,15 +142,13 @@ spec:
                     path: *healthPath
                     port: *tvwebPort
               startup: *startupProbe
-            securityContext: *buildSecurityContext
     defaultPodOptions:
       annotations:
         # entrypoint replaces /etc/localtime; k8tz mounting it there makes the ln -snf fail
         k8tz.io/inject: "false"
       securityContext:
-        runAsNonRoot: true
-        runAsUser: *puid
-        runAsGroup: *pgid
+        # entrypoint starts as root: rewrites /etc (TZ, usermod) then gosu's to PUID/PGID
+        runAsUser: 0
         fsGroup: *pgid
         fsGroupChangePolicy: OnRootMismatch
     service:


### PR DESCRIPTION
The image ships no USER directive: the entrypoint starts as root,
rewrites /etc (localtime, timezone), remaps the app user with
usermod, and drops to PUID/PGID via gosu. The scaffolded
runAsNonRoot/runAsUser: 1000 plus dropped capabilities broke all of
it — ln on /etc/localtime hit EACCES, and gosu would have had no
CAP_SETUID/SETGID to drop privileges with.

Match the securityContext to the image: pod runAsUser 0 (fsGroup
kept for volume ownership), no container-level hardening. This is
the same posture as running the image under docker-compose.
