### PR TITLE
fix(airwave): give workflow engine its Postgres URL

### DIFF
--- a/kubernetes/apps/media/airwave/app/externalsecret.yaml
+++ b/kubernetes/apps/media/airwave/app/externalsecret.yaml
@@ -13,6 +13,8 @@ spec:
     template:
       data:
         DATABASE_URL: "postgresql://${APP}:{{ .${APP}_postgres_password }}@${CNPG_NAME:=pgsql-cluster}-rw.database.svc.cluster.local:5432/${APP}?schema=public"
+        # world-postgres's createWorld() reads WORKFLOW_POSTGRES_URL, not DATABASE_URL
+        WORKFLOW_POSTGRES_URL: "postgresql://${APP}:{{ .${APP}_postgres_password }}@${CNPG_NAME:=pgsql-cluster}-rw.database.svc.cluster.local:5432/${APP}?schema=public"
         BETTER_AUTH_SECRET: "{{ .BETTER_AUTH_SECRET }}"
         ADMIN_EMAIL: "{{ .ADMIN_EMAIL }}"
         ADMIN_PASSWORD: "{{ .ADMIN_PASSWORD }}"


### PR DESCRIPTION
world-postgres's createWorld() reads WORKFLOW_POSTGRES_URL, not
DATABASE_URL. Unset, it falls back to
postgres://world:world@localhost:5432/world, so with
WORKFLOW_ENABLED=1 the engine dialled loopback and the unhandled
start() failure crash-looped the server pod. The docker-compose
.env sets the var; k8s never did. Add it to the ExternalSecret
alongside DATABASE_URL with the same value.
Commit, push, then scale the server back up.
