### PR TITLE
fix(media): point airwave workflow client at the postgres world

### DIFF
--- a/kubernetes/apps/media/airwave/app/helmrelease.yaml
+++ b/kubernetes/apps/media/airwave/app/helmrelease.yaml
@@ -36,6 +36,10 @@ spec:
               TV_APP_ORIGIN: https://${GATUS_SUBDOMAIN}web.${SECRET_DOMAIN}
               BUMPER_MUSIC_DIR: &bumperDir /data/bumper-music
               WORKFLOW_ENABLED: 1
+              # unset, the workflow lib falls back to a local .workflow-data dir
+              # and to localhost:$PORT (the main app) for worker callbacks
+              WORKFLOW_TARGET_WORLD: "@workflow/world-postgres"
+              WORKFLOW_LOCAL_BASE_URL: "http://127.0.0.1:3152"
               PUID: &puid 1000
               PGID: &pgid 1000
               UMASK: &umask "022"


### PR DESCRIPTION
The workflow library resolves two things from env, both with
k8s-hostile defaults:
- WORKFLOW_TARGET_WORLD unset -> client falls back to the Local
  World, reading run state from .workflow-data/ on disk (ENOENT on
  requeued runs)
- WORKFLOW_LOCAL_BASE_URL unset -> worker callbacks POST to
  localhost:$PORT, which is the main app (PORT=3000), hence the
  404 on /.well-known/workflow/v1/flow
