### PR TITLE
fix(media): raise airwave server memory limit to 4Gi

### DIFF
--- a/kubernetes/apps/media/airwave/app/helmrelease.yaml
+++ b/kubernetes/apps/media/airwave/app/helmrelease.yaml
@@ -51,7 +51,8 @@ spec:
                 cpu: 20m
                 memory: 256Mi
               limits:
-                memory: 1Gi
+                # planLineup (AI planner over ~23k episodes) OOMKilled at 1Gi
+                memory: 4Gi
             probes:
               liveness: &probes
                 enabled: true


### PR DESCRIPTION
The planLineup step (AI planner over ~23k episodes) OOMKilled the
1Gi limit twice in a row (exitCode 137); the run then died after 3
step retries. Idle RSS is ~340Mi; 4Gi covers the planner peak.
Commit, push — then trigger a fresh lineup build from the admin workflows page and I'll watch it through.
