### PR TITLE
fix(ai): raise model router response-header timeout to 10m

### DIFF
--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -18,8 +18,6 @@ data:
             context_length: 1048560
           laguna-s-2-1:
             context_length: 1048576
-          deepseek-v4-flash-free:
-            context_length: 200000
           deepseek-v4-flash:
             context_length: 1048576
           # Image models. Hermes has no image-generation auxiliary task, so these
@@ -29,14 +27,14 @@ data:
           qwen-image-3:
             context_length: 65536
     model:
-      default: deepseek-v4-flash-free
+      default: deepseek-v4-flash
       provider: litellm
     # Ordered by what each rung survives: a zen fault, then a WAN fault.
     fallback_providers:
       - provider: litellm
         model: qwen-local # on-node, slow to warm
       - provider: litellm
-        model: deepseek-v4-flash
+        model: laguna-s-2-1
     # Side tasks. Default "auto" would reuse the main chat model for all of
     # them; pinning keeps the cheap/local models on the cheap work.
     auxiliary:
@@ -59,7 +57,7 @@ data:
         max_concurrency: 2
       compression:
         provider: custom:litellm
-        model: laguna-s-2-1 # 1M input window, or deepseek-v4-flash as alt
+        model: laguna-s-2-1
         max_concurrency: 2
       moa_reference:
         provider: custom:litellm
@@ -93,7 +91,7 @@ data:
             - provider: custom:litellm
               model: qwen-local
             - provider: custom:litellm
-              model: deepseek-v4-flash-free
+              model: deepseek-v4-flash
             - provider: custom:litellm
               model: laguna-s-2-1
           aggregator:

--- a/kubernetes/apps/ai/litellm/app/litellmmodels.yaml
+++ b/kubernetes/apps/ai/litellm/app/litellmmodels.yaml
@@ -140,6 +140,7 @@ spec:
     extra:
       input_cost_per_token: 0.0000000120
       output_cost_per_token: 0.0000000500
+# deepseek-v4-flash-free removed from OpenCode Zen ~08/21/26
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json
 apiVersion: litellm.home-operations.com/v1alpha1
@@ -230,37 +231,6 @@ spec:
       input_cost_per_token: 0.0000030000
       cache_read_input_token_cost: 0.0000003000
       output_cost_per_token: 0.0000150000
-      supports_reasoning: true
----
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json
-apiVersion: litellm.home-operations.com/v1alpha1
-kind: LiteLLMModel
-metadata:
-  name: &name deepseek-v4-flash-free
-spec:
-  modelName: *name
-  params:
-    model: openai/deepseek-v4-flash-free
-    # https://opencode.ai/docs/zen#pricing
-    apiBase: https://opencode.ai/zen/v1
-    apiKeyRef:
-      name: litellm-secret
-      key: OPENCODE_API_KEY
-    additional:
-      # Zen serves free models to its own client, all others gets 429 FreeUsageLimitError.
-      extra_headers:
-        User-Agent: opencode/1.0
-  info:
-    mode: chat
-    maxTokens: 128000 # Non-free version supports 384000
-    maxInputTokens: 200000 # Non-free version supports 1048576
-    maxOutputTokens: 128000 # Non-free version supports 384000
-    supportsFunctionCalling: true
-    supportsPromptCaching: true
-    extra:
-      input_cost_per_token: 0.0000000120
-      cache_read_input_token_cost: 0.0000000010
-      output_cost_per_token: 0.0000000500
       supports_reasoning: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json

--- a/kubernetes/apps/ai/llmkube/app/modelrouter.yaml
+++ b/kubernetes/apps/ai/llmkube/app/modelrouter.yaml
@@ -16,12 +16,17 @@ spec:
       # `model:` line and the upstream request both stay unchanged.
       displayName: Qwen3.8-27B
       # Header wait, not generation time. A cold load is bounded by the pool's
-      # swapBudget instead, which this is deliberately decoupled from.
+      # swapBudget instead, which this is deliberately decoupled from. Matches
+      # Litellm's request_timeout (600s) so the router never aborts a generation
       timeout: 5m
     - name: comfyui
       tier: local
       inferenceServiceRef:
         name: comfyui
+  # Default response-header timeout is 120s (router-proxy defaultResponseHeaderTimeout).
+  # For non-streaming chat that caps generation at 2m; raise to litellm's budget.
+  proxy:
+    responseHeaderTimeout: 10m
   # No rules needed: naming a backend routes to it, everything else lands on
   # llama-qwen. Classification and complexity routing do not apply to one GPU.
   defaultRouteStrategy: BackendNameMatch

--- a/kubernetes/apps/media/airwave/app/helmrelease.yaml
+++ b/kubernetes/apps/media/airwave/app/helmrelease.yaml
@@ -49,10 +49,10 @@ spec:
             resources:
               requests:
                 cpu: 20m
-                memory: 256Mi
+                memory: 512Mi
               limits:
                 # planLineup (AI planner over ~23k episodes) OOMKilled at 1Gi
-                memory: 4Gi
+                memory: 2Gi
             probes:
               liveness: &probes
                 enabled: true
@@ -93,7 +93,7 @@ spec:
                 cpu: 20m
                 memory: 512Mi
               limits:
-                memory: 2Gi
+                memory: 1Gi
             probes:
               liveness:
                 <<: *probes


### PR DESCRIPTION
airwave's non-streaming planLineup calls to qwen-local died at 2m with
"net/http: timeout awaiting response headers" because the router-proxy's
default ResponseHeaderTimeout (120s) caps non-streaming generation: llama.cpp
only sends headers after the full completion. Streaming requests passed, so
the 502 was intermittent. Match litellm's request_timeout (600s).

deepseek-v4-flash-free no longer provided by opencode zen.
