### PR TITLE
fix(ai): raise llama-qwen router backend timeout to 10m

### DIFF
--- a/kubernetes/apps/ai/llmkube/app/modelrouter.yaml
+++ b/kubernetes/apps/ai/llmkube/app/modelrouter.yaml
@@ -18,7 +18,7 @@ spec:
       # Header wait, not generation time. A cold load is bounded by the pool's
       # swapBudget instead, which this is deliberately decoupled from. Matches
       # Litellm's request_timeout (600s) so the router never aborts a generation
-      timeout: 5m
+      timeout: 10m
     - name: comfyui
       tier: local
       inferenceServiceRef:


### PR DESCRIPTION
The proxy response-header timeout fix (#3587) unmasked the backend timeout:
non-streaming planLineup still died at exactly 300s (latencyMs:300007 in
router.dispatch) because llama-qwen's `timeout: 5m` caps the per-attempt
deadline. For non-streaming chat that timeout IS generation time — llama.cpp
sends headers only after the full completion. Match litellm's request_timeout.
