### PR TITLE
fix(radarr,prowlarr): set allowed hosts and trusted networks

### DIFF
--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -27,7 +27,9 @@ spec:
               PROWLARR__AUTH__REQUIRED: DisabledForLocalAddresses
               PROWLARR__LOG__DBENABLED: "False"
               PROWLARR__LOG__LEVEL: info
+              PROWLARR__SERVER__ALLOWEDHOSTS: "prowlarr.${SECRET_DOMAIN},prowlarr.media.svc.cluster.local"
               PROWLARR__SERVER__PORT: &port 9696
+              PROWLARR__SERVER__TRUSTEDNETWORKS: 10.42.0.0/16
               PROWLARR__UPDATE__BRANCH: develop
             envFrom:
               - secretRef:
@@ -40,6 +42,9 @@ spec:
                   httpGet:
                     path: ${GATUS_PATH}
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
                   periodSeconds: 30
                   timeoutSeconds: 5
                   failureThreshold: 5

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -26,7 +26,9 @@ spec:
               RADARR__AUTH__REQUIRED: DisabledForLocalAddresses
               RADARR__LOG__DBENABLED: "False"
               RADARR__LOG__LEVEL: info
+              RADARR__SERVER__ALLOWEDHOSTS: "radarr.${SECRET_DOMAIN},radarr.media.svc.cluster.local"
               RADARR__SERVER__PORT: &port 7878
+              RADARR__SERVER__TRUSTEDNETWORKS: 10.42.0.0/16
               RADARR__UPDATE__BRANCH: develop
             envFrom:
               - secretRef:
@@ -45,6 +47,9 @@ spec:
                   httpGet:
                     path: ${GATUS_PATH}
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
                   periodSeconds: 30
                   timeoutSeconds: 5
                   failureThreshold: 5


### PR DESCRIPTION
Mirrors the sonarr setup from #3512 on radarr and prowlarr, both of which now support these settings:

- `*__SERVER__ALLOWEDHOSTS`: `<app>.${SECRET.DOMAIN},<app>.media.svc.cluster.local` - covers the envoy-internal route plus every in-cluster consumer (cleanrr, recyclarr, and prowlarr app-sync all use the `*.media.svc.cluster.local` FQDNs)
- `*__SERVER__TRUSTEDNETWORKS`: `10.42.0.0/16` - trusts X-Forwarded-* headers from the pod network so `DisabledForLocalAddresses` auth keeps seeing real client IPs
- Readiness probes gain a `Host: localhost` header; the kubelet probes with the pod IP as Host, which host filtering rejects with 400 (localhost is always implicitly allowed)
