### PR TITLE
feat(qwen-local): test accuracy of Q4_S with q8_0 kvCache

### DIFF
--- a/kubernetes/apps/ai/litellm/app/litellmmodels.yaml
+++ b/kubernetes/apps/ai/litellm/app/litellmmodels.yaml
@@ -21,7 +21,7 @@ spec:
   info:
     mode: chat
     maxTokens: 32768
-    maxInputTokens: 131072 # contextSize 163840 minus maxOutputTokens; llama.cpp counts both against one pool
+    maxInputTokens: 98304 # contextSize 131072 minus maxOutputTokens; llama.cpp counts both against one pool
     maxOutputTokens: 32768
     supportsFunctionCalling: true
     supportsVision: true
@@ -63,7 +63,7 @@ spec:
   info:
     mode: chat
     maxTokens: 32768
-    maxInputTokens: 131072 # contextSize 163840 minus maxOutputTokens; llama.cpp counts both against one pool
+    maxInputTokens: 98304 # contextSize 131072 minus maxOutputTokens; llama.cpp counts both against one pool
     maxOutputTokens: 32768
     supportsFunctionCalling: true
     supportsVision: true

--- a/kubernetes/apps/ai/litellm/app/llama-qwen.yaml
+++ b/kubernetes/apps/ai/litellm/app/llama-qwen.yaml
@@ -9,29 +9,35 @@ spec:
   # Refer to [Qwen3.8-27B club-3090](https://github.com/noonghunna/club-3090/blob/master/models/qwen3.8-27b/llama-cpp/compose/single/unsloth-iq4nl/q8kv.yml) for more config details.
   source: hf://unsloth/Qwen3.8-27B-GGUF
   files:
-    - Qwen3.8-27B-UD-Q4_K_XL.gguf
+    - Qwen3.8-27B-UD-Q4_K_S.gguf
   mmproj: mmproj-F16.gguf
   format: gguf
-  quantization: UD-Q4_K_XL
+  quantization: UD-Q4_K_S
   hardware:
     accelerator: cuda
     gpu:
       enabled: true
       vendor: nvidia
       layers: 99
-# ┌─────────────────────────────────┬───────────────┬──────────────┐
-# │              Item               │ Now (Q4_K_XL) │ With Q5_K_XL │
-# ├─────────────────────────────────┼───────────────┼──────────────┤
-# │ Model weights                   │ 17.6 GB       │ 20.9 GB      │
-# ├─────────────────────────────────┼───────────────┼──────────────┤
-# │ Vision part (mmproj-F16)        │ ~1 GB         │ ~1 GB        │
-# ├─────────────────────────────────┼───────────────┼──────────────┤
-# │ KV cache (163840 context, q4_0) │ ~4 GB         │ ~4 GB        │
-# ├─────────────────────────────────┼───────────────┼──────────────┤
-# │ Scratch (flash attention)       │ ~1 GB         │ ~1 GB        │
-# ├─────────────────────────────────┼───────────────┼──────────────┤
-# │ Total                           │ ~23.6 GB ✅   │ ~26.9 GB ❌  │
-# └─────────────────────────────────┴───────────────┴──────────────┘
+# ┌─────────────────────────────────┬─────────────────┬─────────────────┬─────────────────┐
+# │              Item               │ Now (XL, q4 KV) │ XL + q8 KV¹     │ K_S + q8 KV     │
+# ├─────────────────────────────────┼─────────────────┼─────────────────┼─────────────────┤
+# │ Context                         │ 163840          │ 163840          │ 131072          │
+# ├─────────────────────────────────┼─────────────────┼─────────────────┼─────────────────┤
+# │ Model weights                   │ 17.6 GB         │ 17.6 GB         │ 15.4 GB         │
+# ├─────────────────────────────────┼─────────────────┼─────────────────┼─────────────────┤
+# │ Vision part (mmproj-F16)        │ ~1 GB           │ ~1 GB           │ ~1 GB           │
+# ├─────────────────────────────────┼─────────────────┼─────────────────┼─────────────────┤
+# │ KV cache                        │ ~4 GB           │ ~4 GB + ~4 RAM  │ ~6.3 GB         │
+# ├─────────────────────────────────┼─────────────────┼─────────────────┼─────────────────┤
+# │ Scratch (flash attention)       │ ~1 GB           │ ~1 GB           │ ~1 GB           │
+# ├─────────────────────────────────┼─────────────────┼─────────────────┼─────────────────┤
+# │ Total                           │ ~23.6 GB ✅     │ ~27.6 GB ⚠      │ ~23.7 GB ✅     │
+# └─────────────────────────────────┴─────────────────┴─────────────────┴─────────────────┘
+# ¹ q8_0 ≈ 50 KiB/token. XL at 163840 ctx exceeds VRAM by ~3.6 GiB;
+#   GGML_CUDA_ENABLE_UNIFIED_MEMORY=1 spills it to RAM at ~100 ms/token per ~2 GiB
+#   (Windows does this invisibly: System Memory Fallback, on by default).
+# Reference: https://www.youtube.com/watch?v=hg26j0erUSo
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/inferenceservice_v1alpha1.json
 apiVersion: inference.llmkube.dev/v1alpha1
@@ -58,12 +64,12 @@ spec:
   env:
     - name: NVIDIA_DRIVER_CAPABILITIES
       value: compute,utility
-  contextSize: 163840
+  contextSize: 131072
   batchSize: 2048
   uBatchSize: 512
   flashAttention: true
-  cacheTypeK: q4_0
-  cacheTypeV: q4_0
+  cacheTypeK: q8_0
+  cacheTypeV: q8_0
   jinja: true
   parallelSlots: 1
   reasoningBudget: 16384


### PR DESCRIPTION
independant research claims q4_0 kvCache performs poorly in long context
unfortunately I dont have much headroom for kvCache to jump to q8_0, so
switching to K_S (model reduced by ~2Gb but supposedly still 95% of BF16
accuracy according to unSloth).

testing to determine if the model was suffering or if this is better.
