### PR TITLE
fix(renovate): stop digest-only PRs for timescale/timescaledb-ha

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -71,5 +71,19 @@
       overrideDatasource: "github-releases",
       overridePackageName: "immich-app/immich",
     },
+    {
+      // Tags are "pg<pgMajor>.<pgMinor>-ts<semver>". Default docker versioning cannot parse
+      description: "TimescaleDB HA uses 'pg<major>.<minor>-ts<semver>' tags",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["timescale/timescaledb-ha"],
+      versioning: "regex:^pg(?<compatibility>\\d+)\\.(?<major>\\d+)-ts(?<minor>\\d+)\\.(?<patch>\\d+)\\.(?<build>\\d+)$",
+    },
+    {
+      description: "No digest-only PRs for TimescaleDB HA",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["timescale/timescaledb-ha"],
+      matchUpdateTypes: ["digest"],
+      enabled: false,
+    },
   ],
 }


### PR DESCRIPTION
Default docker versioning cannot parse the "pg<major>.<minor>-ts<semver>"
tag, so Renovate only ever offered SHA bumps. Add regex versioning for the
real tag shape and disable digest-only updates for this image.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JQBjcuFtgHrLkJjAWXL5Pf
