### PR TITLE
fix(flux): retry cnpg-gated kustomizations every 5m, not hourly

### DIFF
--- a/.agents/skills/add-app/SKILL.md
+++ b/.agents/skills/add-app/SKILL.md
@@ -123,6 +123,7 @@ spec:
         - name: pocket-id # if auth = OIDC (native)
           namespace: security
     interval: 1h
+    retryInterval: 5m # if cnpg
     path: ./kubernetes/apps/{NAMESPACE}/{APP_NAME}/app
     postBuild:
         substitute:
@@ -159,6 +160,7 @@ spec:
 - If GATUS_SUBDOMAIN equals the app name, omit it (the HR will use `{{ .Release.Name }}.${SECRET_DOMAIN}`).
 - If GATUS_SUBDOMAIN differs from app name, include it and use `${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}` in the HR route.
 - `wait: false` for apps, `wait: true` only for infrastructure dependencies.
+- `retryInterval: 5m` only with the cnpg health check. Without it Flux falls back to `interval`, so a Kustomization failed by a database restart stays failed for a full hour.
 
 ---
 

--- a/docs/context/components.md
+++ b/docs/context/components.md
@@ -79,7 +79,14 @@ healthCheckExprs:
 dependsOn:
     - name: cnpg-cluster
       namespace: database
+interval: 1h
+retryInterval: 5m
 ```
+
+`retryInterval` is load-bearing here. The health check marks the Kustomization failed whenever the
+cluster goes `Ready: False` — a CNPG image bump does that on every rolling restart. Flux defaults
+`retryInterval` to `interval`, so without this line the app stays failed for a full hour after the
+database recovers, and only a manual `just kube reconcile-ks` clears it sooner.
 
 Creates three resources in the app's namespace:
 

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -22,6 +22,7 @@ spec:
   # need to create CNPG superuser init job or use postgres-operator's
   # custom query to bootstrap the litellm database/user on first deploy.
   interval: 1h
+  retryInterval: 5m
   path: ./kubernetes/apps/ai/litellm/app
   postBuild:
     substitute:

--- a/kubernetes/apps/ai/memini/ks.yaml
+++ b/kubernetes/apps/ai/memini/ks.yaml
@@ -14,6 +14,7 @@ spec:
       namespace: database
     - name: llmkube
   interval: 1h
+  retryInterval: 5m
   path: ./kubernetes/apps/ai/memini/app
   postBuild:
     substitute:

--- a/kubernetes/apps/database/pgadmin/ks.yaml
+++ b/kubernetes/apps/database/pgadmin/ks.yaml
@@ -14,6 +14,7 @@ spec:
       namespace: kopiur-system
     - name: cnpg-cluster
   interval: 1h
+  retryInterval: 5m
   path: ./kubernetes/apps/database/pgadmin/app
   postBuild:
     substitute:

--- a/kubernetes/apps/default/cetranscript/ks.yaml
+++ b/kubernetes/apps/default/cetranscript/ks.yaml
@@ -15,6 +15,7 @@ spec:
     - name: dragonfly-cluster
       namespace: database
   interval: 1h
+  retryInterval: 5m
   path: ./kubernetes/apps/default/cetranscript/app
   postBuild:
     substitute:

--- a/kubernetes/apps/default/homebox/ks.yaml
+++ b/kubernetes/apps/default/homebox/ks.yaml
@@ -18,6 +18,7 @@ spec:
     - name: pocket-id
       namespace: security
   interval: 1h
+  retryInterval: 5m
   path: ./kubernetes/apps/default/homebox/app
   postBuild:
     substitute:

--- a/kubernetes/apps/default/immich/ks.yaml
+++ b/kubernetes/apps/default/immich/ks.yaml
@@ -18,6 +18,7 @@ spec:
     - name: pocket-id
       namespace: security
   interval: 1h
+  retryInterval: 5m
   path: ./kubernetes/apps/default/immich/app
   postBuild:
     substitute:

--- a/kubernetes/apps/default/mealie/ks.yaml
+++ b/kubernetes/apps/default/mealie/ks.yaml
@@ -18,6 +18,7 @@ spec:
     - name: pocket-id
       namespace: security
   interval: 1h
+  retryInterval: 5m
   path: ./kubernetes/apps/default/mealie/app
   postBuild:
     substitute:

--- a/kubernetes/apps/media/airwave/ks.yaml
+++ b/kubernetes/apps/media/airwave/ks.yaml
@@ -13,6 +13,7 @@ spec:
     - name: cnpg-cluster
       namespace: database
   interval: 1h
+  retryInterval: 5m
   path: ./kubernetes/apps/media/airwave/app
   postBuild:
     substitute:

--- a/kubernetes/apps/media/tracearr/ks.yaml
+++ b/kubernetes/apps/media/tracearr/ks.yaml
@@ -15,6 +15,7 @@ spec:
     - name: dragonfly-cluster
       namespace: database
   interval: 1h
+  retryInterval: 5m
   path: ./kubernetes/apps/media/tracearr/app
   postBuild:
     substitute:

--- a/kubernetes/apps/observability/gatus/ks.yaml
+++ b/kubernetes/apps/observability/gatus/ks.yaml
@@ -13,6 +13,7 @@ spec:
     - name: cnpg-cluster
       namespace: database
   interval: 1h
+  retryInterval: 5m
   path: ./kubernetes/apps/observability/gatus/app
   postBuild:
     substitute:

--- a/kubernetes/apps/observability/grafana-operator/ks.yaml
+++ b/kubernetes/apps/observability/grafana-operator/ks.yaml
@@ -34,6 +34,7 @@ spec:
     - name: pocket-id
       namespace: security
   interval: 1h
+  retryInterval: 5m
   path: ./kubernetes/apps/observability/grafana-operator/instance
   postBuild:
     substitute:

--- a/kubernetes/apps/observability/kite/ks.yaml
+++ b/kubernetes/apps/observability/kite/ks.yaml
@@ -15,6 +15,7 @@ spec:
     - name: pocket-id
       namespace: security
   interval: 1h
+  retryInterval: 5m
   path: ./kubernetes/apps/observability/kite/app
   postBuild:
     substitute:

--- a/kubernetes/apps/security/pocket-id/ks.yaml
+++ b/kubernetes/apps/security/pocket-id/ks.yaml
@@ -41,6 +41,7 @@ spec:
     - name: kopiur
       namespace: kopiur-system
   interval: 1h
+  retryInterval: 5m
   path: ./kubernetes/apps/security/pocket-id/instance
   postBuild:
     substitute:


### PR DESCRIPTION
Every ks.yaml with a CNPG Cluster healthCheck is marked failed when the
cluster goes Ready:False, which an image bump does on each rolling restart.
Flux defaults retryInterval to interval, so the app stayed failed for a full
hour after the database recovered. Set retryInterval: 5m on all 13, and
record it in components.md and the add-app template.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0135LpBQPQwhgKDEGTqkpHgU
