### PR TITLE
fix(observability): drop dead topologySpreadConstraints from grafana-operator

### DIFF
--- a/kubernetes/apps/observability/grafana-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana-operator/app/helmrelease.yaml
@@ -14,10 +14,3 @@ spec:
       enabled: true
     serviceMonitor:
       enabled: true
-    topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-        labelSelector:
-          matchLabels:
-            app.kubernetes.io/component: operator


### PR DESCRIPTION
The grafana-operator chart has no topologySpreadConstraints value — only
nodeSelector, affinity and tolerations — so Helm dropped the block and the
running pod spec never carried it. It would be moot anyway: the chart runs
one replica behind leader election.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0135LpBQPQwhgKDEGTqkpHgU
