### PR TITLE
feat(cnpg)!: promote pgcluster-default and repoint every consumer

### DIFF
--- a/docs/context/components.md
+++ b/docs/context/components.md
@@ -65,7 +65,7 @@ components:
 postBuild:
     substitute:
         APP: *app
-        CNPG_NAME: &postgresAppName pgsql-cluster # or pgvector-cluster
+        CNPG_NAME: &postgresAppName pgcluster-default # or pgvector-cluster
 healthChecks:
     - apiVersion: &postgresVersion postgresql.cnpg.io/v1
       kind: &postgresKind Cluster
@@ -112,7 +112,7 @@ initContainers:
                   name: "{{ .Release.Name }}-initdb-secret"
 ```
 
-`CNPG_NAME` picks the cluster: `pgsql-cluster` for general apps, `pgvector-cluster` for apps needing vector search ([ADR-0011](../adr/0011-pgvector-cluster-split.md)). It defaults to `pgsql-cluster` in the component (`${CNPG_NAME:=pgsql-cluster}`) — but set it explicitly anyway, because the `healthChecks` block below needs the anchor. Both clusters live in the `database` namespace; `storage.md` says what each is for.
+`CNPG_NAME` picks the cluster: `pgcluster-default` for general apps, `pgvector-cluster` for apps needing vector search ([ADR-0011](../adr/0011-pgvector-cluster-split.md)). It defaults to `pgcluster-default` in the component (`${CNPG_NAME:=pgcluster-default}`) — but set it explicitly anyway, because the `healthChecks` block below needs the anchor. Both clusters live in the `database` namespace; `storage.md` says what each is for.
 
 The generated `host` is `{cluster}-rw…`, shared by every app on that cluster — apps read it from the Secret, they never compose it.
 

--- a/docs/context/storage.md
+++ b/docs/context/storage.md
@@ -2,7 +2,7 @@
 
 ## ⚠️ Gotchas & Interactions
 
-- **CNPG endpoints are named after the cluster, not the app:** the `host` key is `{cluster}-rw.database.svc.cluster.local` — `pgsql-cluster-rw` or `pgvector-cluster-rw`, shared by every app on that cluster. Use the `host` key from `${APP}-pguser-secret` rather than composing a name. Never point an app at `-ro`; that is the read replica.
+- **CNPG endpoints are named after the cluster, not the app:** the `host` key is `{cluster}-rw.database.svc.cluster.local` — `pgcluster-default-rw` or `pgvector-cluster-rw`, shared by every app on that cluster. Use the `host` key from `${APP}-pguser-secret` rather than composing a name. Never point an app at `-ro`; that is the read replica.
 - **Ceph mutes four `AUTH_INSECURE_*` warnings on purpose:** Ceph Tentacle (v20) flags the older `aes` cephx cipher. Daemon keys (mon/mgr/osd) are rotated to `aes256k` via `security.cephx.daemon`, but CSI keys are pinned to `aes` because `aes256k` needs a host kernel of 7.0+ and the Talos nodes are below that. The remaining warnings cannot clear, so they are muted declaratively in `cephClusterSpec.healthCheck.muteHealthWarning`. Unmute — and drop `security.cephx.csi.keyType` — once the nodes reach kernel 7.0+.
 - **openebs-hostpath is node-local:** Data is tied to the node. A pod rescheduling to a different node loses access to its PVC.
 
@@ -29,10 +29,10 @@ Backing up an app's PVC, the substitution vars, and the restore procedure are al
 
 Clusters in the `database` namespace ([ADR-0004](../adr/0004-cloudnativepg-for-postgresql.md), [ADR-0011](../adr/0011-pgvector-cluster-split.md)):
 
-| Cluster            | Purpose                | Notes                                                           |
-| ------------------ | ---------------------- | --------------------------------------------------------------- |
-| `pgsql-cluster`    | All general apps       | Default                                                         |
-| `pgvector-cluster` | Immich + pgvector apps | Shared cluster for apps needing vector search; adds vectorchord |
+| Cluster             | Purpose                | Notes                                                           |
+| ------------------- | ---------------------- | --------------------------------------------------------------- |
+| `pgcluster-default` | All general apps       | Default                                                         |
+| `pgvector-cluster`  | Immich + pgvector apps | Shared cluster for apps needing vector search; adds vectorchord |
 
 The PostgreSQL major version is not recorded here — it is whatever `imageName`
 says in each cluster's manifest under `kubernetes/apps/database/cnpg/`. Renovate

--- a/docs/scripts/verify.py
+++ b/docs/scripts/verify.py
@@ -100,7 +100,8 @@ def storage_classes():
 def cnpg_clusters():
     on_disk = {p.name for p in (ROOT / "kubernetes" / "apps" / "database" / "cnpg").iterdir() if p.is_dir()}
     named = set(re.findall(r"^\| `([a-z0-9-]+)`\s*\|", section("storage.md", "CNPG (PostgreSQL)"), re.M))
-    named |= set(re.findall(r"CNPG_NAME:[^\n#]*?\b([a-z0-9-]*cluster)\b", context_text()))
+    # "cluster" can lead or trail the name: pgsql-cluster, pgcluster-default.
+    named |= set(re.findall(r"CNPG_NAME:[^\n#]*?\b([a-z0-9-]*cluster[a-z0-9-]*)\b", context_text()))
     skip = ignored("cnpg")
     return [
         f"docs name CNPG cluster `{c}`, no directory under apps/database/cnpg/"

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -27,7 +27,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      CNPG_NAME: &postgresAppName pgsql-cluster
+      CNPG_NAME: &postgresAppName pgcluster-default
       PG_VER: "17"
     substituteFrom:
       - kind: Secret

--- a/kubernetes/apps/database/cnpg/pgcluster-default/cluster.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-default/cluster.yaml
@@ -16,28 +16,6 @@ spec:
     size: 20Gi
     storageClass: openebs-hostpath
 
-  # Blue/green rename of pgsql-cluster. A Cluster cannot be renamed, so this one
-  # bootstraps from blue's object store and then stays in continuous recovery,
-  # replaying blue's archived WAL until it is promoted.
-  # https://cloudnative-pg.io/plugin-barman-cloud/docs/usage/#restoring-a-cluster
-  bootstrap:
-    recovery:
-      source: blue
-
-  # Promotion (enabled: false) is irreversible -- see Task 8.
-  replica:
-    enabled: true
-    source: blue
-
-  externalClusters:
-    - name: blue
-      plugin:
-        name: barman-cloud.cloudnative-pg.io
-        parameters:
-          # read-only: the OLD cluster's prefix. Never written to.
-          barmanObjectName: pgsql-cluster
-          serverName: pgsql-cluster
-
   superuserSecret:
     name: cnpg-secret
   enableSuperuserAccess: true

--- a/kubernetes/apps/database/cnpg/pgcluster-default/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-default/scheduledbackup.yaml
@@ -13,7 +13,5 @@ spec:
   # CNPG cron is 6-field (seconds first), not the 5-field Kubernetes CronJob format
   # Runs at ~1 AM America/New_York (6 AM UTC during EDT, 5 AM UTC during EST)
   schedule: "0 0 6 * * *"
-  # A replica cluster cannot take a base backup. Un-suspended at promotion (Task 8).
-  suspend: true
   immediate: true
   backupOwnerReference: self

--- a/kubernetes/apps/database/pgadmin/app/config/servers.json
+++ b/kubernetes/apps/database/pgadmin/app/config/servers.json
@@ -1,9 +1,9 @@
 {
   "Servers": {
     "1": {
-      "Name": "pgsql-cluster",
+      "Name": "pgcluster-default",
       "Group": "Servers",
-      "Host": "pgsql-cluster-rw.database.svc.cluster.local",
+      "Host": "pgcluster-default-rw.database.svc.cluster.local",
       "Port": 5432,
       "MaintenanceDB": "postgres",
       "Username": "postgres",
@@ -15,9 +15,23 @@
       "TunnelAuthentication": 0
     },
     "2": {
-      "Name": "immich17",
+      "Name": "pgvector-cluster",
       "Group": "Servers",
-      "Host": "immich17-rw.database.svc.cluster.local",
+      "Host": "pgvector-cluster-rw.database.svc.cluster.local",
+      "Port": 5432,
+      "MaintenanceDB": "postgres",
+      "Username": "postgres",
+      "SSLMode": "prefer",
+      "SSLCompression": 0,
+      "Timeout": 10,
+      "UseSSHTunnel": 0,
+      "TunnelPort": "22",
+      "TunnelAuthentication": 0
+    },
+    "3": {
+      "Name": "pgcluster-timescale",
+      "Group": "Servers",
+      "Host": "pgcluster-timescale-rw.database.svc.cluster.local",
       "Port": 5432,
       "MaintenanceDB": "postgres",
       "Username": "postgres",

--- a/kubernetes/apps/database/pgadmin/ks.yaml
+++ b/kubernetes/apps/database/pgadmin/ks.yaml
@@ -23,7 +23,7 @@ spec:
       KOPIUR_CAPACITY: 1Gi
       KOPIUR_PUID: "5050"
       KOPIUR_PGID: "5050"
-      CNPG_NAME: &postgresAppName pgsql-cluster
+      CNPG_NAME: &postgresAppName pgcluster-default
     substituteFrom:
       - kind: Secret
         name: cluster-secrets

--- a/kubernetes/apps/default/cetranscript/app/externalsecret.yaml
+++ b/kubernetes/apps/default/cetranscript/app/externalsecret.yaml
@@ -31,7 +31,7 @@ spec:
     name: *name
     template:
       data:
-        DATABASE_URL: "postgresql://${APP}:{{ .cetranscript_postgres_password }}@pgsql-cluster.database.svc.cluster.local:5432/${APP}"
+        DATABASE_URL: "postgresql://${APP}:{{ .cetranscript_postgres_password }}@${CNPG_NAME:=pgcluster-default}-rw.database.svc.cluster.local:5432/${APP}"
         VALKEY_URL: "redis://dragonfly-cluster.database.svc.cluster.local:6379/7"
         S3_ENDPOINT: "{{ .S3_ENDPOINT }}"
         S3_ACCESS_KEY_ID: "{{ .S3_ACCESS_KEY_ID }}"

--- a/kubernetes/apps/default/cetranscript/ks.yaml
+++ b/kubernetes/apps/default/cetranscript/ks.yaml
@@ -21,7 +21,7 @@ spec:
     substitute:
       APP: *app
       GATUS_PATH: /health
-      CNPG_NAME: &postgresAppName pgsql-cluster
+      CNPG_NAME: &postgresAppName pgcluster-default
     substituteFrom:
       - kind: Secret
         name: cluster-secrets

--- a/kubernetes/apps/default/homebox/app/externalsecret.yaml
+++ b/kubernetes/apps/default/homebox/app/externalsecret.yaml
@@ -18,7 +18,7 @@ spec:
         HBOX_MAILER_USERNAME: "{{ .SMTP_USERNAME }}"
         HBOX_MAILER_PASSWORD: "{{ .SMTP_PASSWORD }}"
         HBOX_MAILER_FROM: "{{ .SMTP_FROM }}"
-        HBOX_DATABASE_HOST: "${CNPG_NAME:=pgsql-cluster}-rw.database.svc.cluster.local"
+        HBOX_DATABASE_HOST: "${CNPG_NAME:=pgcluster-default}-rw.database.svc.cluster.local"
         HBOX_DATABASE_PORT: "5432"
         HBOX_DATABASE_DATABASE: "${APP}"
         HBOX_DATABASE_USERNAME: "${APP}"

--- a/kubernetes/apps/default/homebox/ks.yaml
+++ b/kubernetes/apps/default/homebox/ks.yaml
@@ -25,7 +25,7 @@ spec:
       APP: *app
       GATUS_SUBDOMAIN: inv
       GATUS_PATH: /api/v1/status
-      CNPG_NAME: &postgresAppName pgsql-cluster
+      CNPG_NAME: &postgresAppName pgcluster-default
     substituteFrom:
       - kind: Secret
         name: cluster-secrets

--- a/kubernetes/apps/default/mealie/ks.yaml
+++ b/kubernetes/apps/default/mealie/ks.yaml
@@ -25,7 +25,7 @@ spec:
       APP: *app
       GATUS_SUBDOMAIN: mp
       GATUS_PATH: /api/app/about
-      CNPG_NAME: &postgresAppName pgsql-cluster
+      CNPG_NAME: &postgresAppName pgcluster-default
     substituteFrom:
       - kind: Secret
         name: cluster-secrets

--- a/kubernetes/apps/media/airwave/app/externalsecret.yaml
+++ b/kubernetes/apps/media/airwave/app/externalsecret.yaml
@@ -12,9 +12,9 @@ spec:
     name: *name
     template:
       data:
-        DATABASE_URL: "postgresql://${APP}:{{ .${APP}_postgres_password }}@${CNPG_NAME:=pgsql-cluster}-rw.database.svc.cluster.local:5432/${APP}?schema=public"
+        DATABASE_URL: "postgresql://${APP}:{{ .${APP}_postgres_password }}@${CNPG_NAME:=pgcluster-default}-rw.database.svc.cluster.local:5432/${APP}?schema=public"
         # world-postgres's createWorld() reads WORKFLOW_POSTGRES_URL, not DATABASE_URL
-        WORKFLOW_POSTGRES_URL: "postgresql://${APP}:{{ .${APP}_postgres_password }}@${CNPG_NAME:=pgsql-cluster}-rw.database.svc.cluster.local:5432/${APP}?schema=public"
+        WORKFLOW_POSTGRES_URL: "postgresql://${APP}:{{ .${APP}_postgres_password }}@${CNPG_NAME:=pgcluster-default}-rw.database.svc.cluster.local:5432/${APP}?schema=public"
         BETTER_AUTH_SECRET: "{{ .BETTER_AUTH_SECRET }}"
         ADMIN_EMAIL: "{{ .ADMIN_EMAIL }}"
         ADMIN_PASSWORD: "{{ .ADMIN_PASSWORD }}"

--- a/kubernetes/apps/media/airwave/ks.yaml
+++ b/kubernetes/apps/media/airwave/ks.yaml
@@ -19,7 +19,7 @@ spec:
     substitute:
       APP: *app
       GATUS_SUBDOMAIN: tv
-      CNPG_NAME: &postgresAppName pgsql-cluster
+      CNPG_NAME: &postgresAppName pgcluster-default
     substituteFrom:
       - kind: Secret
         name: cluster-secrets

--- a/kubernetes/apps/observability/gatus/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/gatus/app/externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
       data:
         PUSHOVER_ALERTMANAGER_TOKEN: "{{ .PUSHOVER_ALERTMANAGER_TOKEN }}"
         PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
-        DB_URI: "postgresql://${APP}:{{ .gatus_postgres_password }}@pgsql-cluster.database.svc.cluster.local:5432/${APP}"
+        DB_URI: "postgresql://${APP}:{{ .gatus_postgres_password }}@${CNPG_NAME:=pgcluster-default}-rw.database.svc.cluster.local:5432/${APP}"
   dataFrom:
     - extract:
         key: /observability/gatus

--- a/kubernetes/apps/observability/gatus/ks.yaml
+++ b/kubernetes/apps/observability/gatus/ks.yaml
@@ -20,7 +20,7 @@ spec:
       APP: *app
       GATUS_PATH: /health
       GATUS_SUBDOMAIN: status
-      CNPG_NAME: &postgresAppName pgsql-cluster
+      CNPG_NAME: &postgresAppName pgcluster-default
     substituteFrom:
       - name: cluster-secrets
         kind: Secret

--- a/kubernetes/apps/observability/grafana-operator/ks.yaml
+++ b/kubernetes/apps/observability/grafana-operator/ks.yaml
@@ -39,7 +39,7 @@ spec:
   postBuild:
     substitute:
       APP: grafana
-      CNPG_NAME: &postgresAppName pgsql-cluster
+      CNPG_NAME: &postgresAppName pgcluster-default
       GATUS_SUBDOMAIN: grafana
     substituteFrom:
       - name: cluster-secrets

--- a/kubernetes/apps/observability/kite/ks.yaml
+++ b/kubernetes/apps/observability/kite/ks.yaml
@@ -22,7 +22,7 @@ spec:
       APP: *app
       GATUS_SUBDOMAIN: k8s
       GATUS_PATH: /healthz
-      CNPG_NAME: &postgresAppName pgsql-cluster
+      CNPG_NAME: &postgresAppName pgcluster-default
     substituteFrom:
       - kind: Secret
         name: cluster-secrets

--- a/kubernetes/apps/security/pocket-id/ks.yaml
+++ b/kubernetes/apps/security/pocket-id/ks.yaml
@@ -46,7 +46,7 @@ spec:
   postBuild:
     substitute:
       APP: pocketid
-      CNPG_NAME: &postgresAppName pgsql-cluster
+      CNPG_NAME: &postgresAppName pgcluster-default
       GATUS_SUBDOMAIN: id
       KOPIUR_CAPACITY: 1Gi
       KOPIUR_PUID: "65534"

--- a/kubernetes/components/cnpg/README.md
+++ b/kubernetes/components/cnpg/README.md
@@ -2,7 +2,7 @@
 
 This component adds three things to an app: `${APP}-initdb-secret` (consumed by the `postgres-init` init container), `${APP}-pguser-secret` (host/user/password/uri/dsn), and a `${APP}-pg-backups` CronJob. All of it reads the role password from aKeyless `/database/cnpg-users`, field `${APP}_postgres_password`.
 
-`${CNPG_NAME:=pgsql-cluster}` comes from each app's `ks.yaml` `postBuild.substitute`.
+`${CNPG_NAME:=pgcluster-default}` comes from each app's `ks.yaml` `postBuild.substitute`.
 
 ### Getting the password into aKeyless
 

--- a/kubernetes/components/cnpg/cronjob.yaml
+++ b/kubernetes/components/cnpg/cronjob.yaml
@@ -29,7 +29,7 @@ spec:
                 - /backup.sh
               env:
                 - name: POSTGRES_HOST
-                  value: ${CNPG_NAME:=pgsql-cluster}-rw.database.svc.cluster.local
+                  value: ${CNPG_NAME:=pgcluster-default}-rw.database.svc.cluster.local
                 - name: POSTGRES_DB
                   value: ${APP}
                 - name: POSTGRES_USER

--- a/kubernetes/components/cnpg/externalsecret.yaml
+++ b/kubernetes/components/cnpg/externalsecret.yaml
@@ -13,7 +13,7 @@ spec:
     template:
       data:
         INIT_POSTGRES_DBNAME: ${APP}
-        INIT_POSTGRES_HOST: ${CNPG_NAME:=pgsql-cluster}-rw.database.svc.cluster.local
+        INIT_POSTGRES_HOST: ${CNPG_NAME:=pgcluster-default}-rw.database.svc.cluster.local
         INIT_POSTGRES_USER: ${APP}
         INIT_POSTGRES_PASS: "{{ .${APP}_postgres_password }}"
         INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
@@ -37,13 +37,13 @@ spec:
     template:
       data:
         port: "5432"
-        host: ${CNPG_NAME:=pgsql-cluster}-rw.database.svc.cluster.local
-        ro_host: ${CNPG_NAME:=pgsql-cluster}-ro.database.svc.cluster.local
+        host: ${CNPG_NAME:=pgcluster-default}-rw.database.svc.cluster.local
+        ro_host: ${CNPG_NAME:=pgcluster-default}-ro.database.svc.cluster.local
         user: ${APP}
         password: "{{ .${APP}_postgres_password }}"
         db: "${APP}"
-        uri: postgresql://${APP}:{{ .${APP}_postgres_password }}@${CNPG_NAME:=pgsql-cluster}-rw.database.svc.cluster.local:5432/${APP}
-        dsn: "host=${CNPG_NAME:=pgsql-cluster}-rw.database.svc.cluster.local port=5432 user=${APP} password={{ .${APP}_postgres_password }} dbname=${APP} sslmode=disable"
+        uri: postgresql://${APP}:{{ .${APP}_postgres_password }}@${CNPG_NAME:=pgcluster-default}-rw.database.svc.cluster.local:5432/${APP}
+        dsn: "host=${CNPG_NAME:=pgcluster-default}-rw.database.svc.cluster.local port=5432 user=${APP} password={{ .${APP}_postgres_password }} dbname=${APP} sslmode=disable"
   dataFrom:
     - extract:
         key: /database/cnpg-users


### PR DESCRIPTION
Closes part of #3343 — this is **Task 8 steps 6–8** of the phase 1 rename.

## ⛔ Do not merge yet

**Merging this PR performs the promotion.** It is irreversible.

These must all be true first, in order:

1. A fresh `Backup` of `pgsql-cluster` has completed — this is the abort target
2. `flux get ks -A | grep -v True` is empty
3. Apps are quiesced and **client connections on blue are zero** (measured: drains in ~5s)
4. `pg_switch_wal()` has run on `pgsql-cluster`
5. `pgcluster-default` has replayed to that exact LSN

Merging before step 5 promotes the cluster while apps are still writing to blue. That is exactly how #1211 silently lost every write between the recovery point and the quiesce, and closing that window is why this plan was rewritten.

Kept as a **draft** for that reason.

## What it does

| Group | Files |
| --- | --- |
| Promotion | `pgcluster-default/cluster.yaml` drops `bootstrap`/`replica`/`externalClusters`; `scheduledbackup.yaml` drops `suspend` |
| `CNPG_NAME` anchors | 10 app `ks.yaml` |
| Substitution defaults | `components/cnpg/{cronjob,externalsecret}.yaml` + README, `homebox` and `airwave` externalsecrets |
| Hardcoded hostnames | `cetranscript`, `gatus`, `pgadmin` |
| Docs | `components.md`, `storage.md`, `verify.py` |

## The part worth reviewing

Three consumers **hardcoded the hostname and carry no `CNPG_NAME`**, so the original survey — which grepped only for `CNPG_NAME` — missed them.

Because `pgsql-cluster` keeps running until it is deleted, missing them would **not** have errored. Those apps would have connected to the old cluster and kept writing there: data silently split across two clusters, with `cetranscript` among them.

`cetranscript` and `gatus` are converted to the substitution rather than to a new literal, so the same trap cannot recur when `pgvector-cluster` is renamed in phase 6. Both also move to the `-rw` endpoint the component and every other app already use.

`pgadmin/app/config/servers.json` stays a literal on purpose — it is a UI bookmark list of several clusters, not one app-to-cluster binding. Its stale `immich17` entry named a cluster that does not exist; corrected to `pgvector-cluster`, and the missing `pgcluster-timescale` added.

`docs/scripts/verify.py` matched cluster names with `([a-z0-9-]*cluster)`, which assumes the name **ends** in "cluster". `pgcluster-default` matched as the token `pgcluster` and the check failed on a directory that does not exist. Widened — this would have hit `pgcluster-vector` too.

## Verification

| Check | Result |
| --- | --- |
| `flate test all` | 370 passed |
| `just docs test` | 6 passed |
| Rendered `pgcluster-default-rw` | 52 |
| Rendered `pgsql-cluster-rw` | **0** |
| Unsubstituted `${CNPG_NAME` | **0** |

The only remaining `pgsql-cluster` objects are blue itself — correct, it stays until Task 12 so the rollback stays cheap through the soak.

## Rollback

| Condition | Action | Data lost |
| --- | --- | --- |
| Merged, apps still stopped | Revert this PR, point `CNPG_NAME` back at `pgsql-cluster` | None — blue has not been written to since `pg_switch_wal()` |
| Apps resumed and writing | Revert and replay by hand, or restore | Everything since cutover |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCCNW3qRSZmuQnqDZ82t34