### PR TITLE
feat(cnpg): add pgcluster-green to rehearse the 17 to 18 upgrade

### DIFF
--- a/kubernetes/apps/database/cnpg/ks.yaml
+++ b/kubernetes/apps/database/cnpg/ks.yaml
@@ -156,3 +156,32 @@ spec:
     namespace: flux-system
   targetNamespace: database
   wait: true
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cnpg-pgcluster-green
+spec:
+  dependsOn:
+    - name: cnpg-operator
+    - name: cnpg-barman-cloud
+    # provides the pgcluster-default ObjectStore this recovers from
+    - name: cnpg-pgcluster-default
+    - name: openebs
+      namespace: openebs-system
+  interval: 1h
+  path: ./kubernetes/apps/database/cnpg/pgcluster-green
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cnpg-secret
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  wait: true

--- a/kubernetes/apps/database/cnpg/pgcluster-green/cluster.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-green/cluster.yaml
@@ -1,0 +1,61 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: &name pgcluster-green
+  annotations:
+    cnpg.io/skipEmptyWalArchiveCheck: "enabled"
+spec:
+  instances: 3
+  # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
+  imageName: ghcr.io/cloudnative-pg/postgresql:17
+  primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: switchover
+  storage:
+    size: 10Gi
+    storageClass: openebs-hostpath
+
+  # Throwaway rehearsal clone of pgcluster-default, used only to measure and de-risk the
+  # 17 -> 18 in-place upgrade. It recovers from production's B2 prefix read-only and has NO
+  # plugins block, so it archives nowhere and cannot write into that prefix. Deleted in Task 16.
+  bootstrap:
+    recovery:
+      source: source
+
+  externalClusters:
+    - name: source
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          # read-only: production's prefix. Never written to.
+          barmanObjectName: pgcluster-default
+          serverName: pgcluster-default
+
+  superuserSecret:
+    name: cnpg-secret
+  enableSuperuserAccess: true
+  postgresql:
+    parameters:
+      max_connections: "200"
+      shared_buffers: 256MB
+    pg_hba:
+      - host all all 10.42.0.0/16 scram-sha-256
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      memory: 2Gi
+  monitoring:
+    enablePodMonitor: true
+  # enablePDB replaces nodeMaintenanceWindow https://cloudnative-pg.io/documentation/1.26/kubernetes_upgrade/#pod-disruption-budgets
+  enablePDB: true
+  # Fix for non AWS backup https://github.com/cloudnative-pg/cloudnative-pg/issues/7715#issuecomment-2935582020
+  env:
+    - name: AWS_REQUEST_CHECKSUM_CALCULATION
+      value: when_required
+    - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+      value: when_required
+    - name: TZ
+      value: ${TIMEZONE:-UTC}

--- a/kubernetes/apps/database/cnpg/pgcluster-green/kustomization.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-green/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cluster.yaml


### PR DESCRIPTION
Disposable clone of pgcluster-default, used only to measure and de-risk the declarative in-place major upgrade before production runs it. Deleted once phase 3 has produced an outage estimate and a verified PG18 result.

It recovers from pgcluster-default's B2 prefix read-only and carries NO plugins block, so it archives nowhere and cannot write into that prefix. Storage is 10Gi rather than 20Gi; the source is 317MB after the orphan drop.

It clones pgcluster-default rather than reusing pgsql-cluster on purpose. pgsql-cluster still holds the five orphan databases -- 704MB against 317MB -- so pg_upgrade there would process 2.2x the real surface and return an inflated outage estimate. Rehearsing on it would also destroy it: pg_upgrade runs with --link and replaces the original PGDATA on success, so the warm PG17 rollback would be consumed by the very test meant to protect the upgrade.

No app connects to green and nothing else references it.

Refs: .agents/superpowers/plans/2026-08-13-pg17-to-pg18-upgrade.md


Claude-Session: https://claude.ai/code/session_01KCCNW3qRSZmuQnqDZ82t34