### PR TITLE
feat(cnpg)!: upgrade pgcluster-default to PostgreSQL 18

### DIFF
--- a/docs/context/components.md
+++ b/docs/context/components.md
@@ -96,7 +96,7 @@ Creates three resources in the app's namespace:
 | `${APP}-initdb-secret` | ExternalSecret | `INIT_POSTGRES_*` vars for the init container                                       |
 | `${APP}-pg-backups`    | CronJob        | pgdump to NFS on clonenas, `5 */4 * * *`                                            |
 
-`PG_VER` (default `17`) selects the `postgres-backup-local` image tag for that CronJob — override it only if the app's cluster runs a different major version.
+`PG_VER` (default `18`) selects the `postgres-backup-local` image tag for that CronJob — override it only if the app's cluster runs a different major version. `memini` and `immich` pin `17` because they are on `pgvector-cluster`, which is still PostgreSQL 17.
 
 The component stops at credentials. The app's HelmRelease has to run the init container that creates the role and database:
 

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -28,7 +28,7 @@ spec:
     substitute:
       APP: *app
       CNPG_NAME: &postgresAppName pgcluster-default
-      PG_VER: "17"
+      PG_VER: "18"
     substituteFrom:
       - kind: Secret
         name: cluster-secrets

--- a/kubernetes/apps/database/cnpg/pgcluster-default/cluster.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-default/cluster.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   instances: 3
   # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
-  imageName: ghcr.io/cloudnative-pg/postgresql:17
+  imageName: ghcr.io/cloudnative-pg/postgresql:18
   primaryUpdateStrategy: unsupervised
   primaryUpdateMethod: switchover
   storage:
@@ -48,4 +48,7 @@ spec:
       isWALArchiver: true
       parameters:
         barmanObjectName: *name
-        serverName: *name
+        # pg_upgrade resets the timeline and assigns a new system ID, so the PG18
+        # WAL stream is not continuous with the PG17 one. Sharing a serverName
+        # would put two discontinuous streams under one prefix and break restore.
+        serverName: pgcluster-default-v18

--- a/kubernetes/components/cnpg/cronjob.yaml
+++ b/kubernetes/components/cnpg/cronjob.yaml
@@ -23,7 +23,7 @@ spec:
           containers:
             - name: *name
               # https://github.com/prodrigestivill/docker-postgres-backup-local/discussions/109
-              image: docker.io/prodrigestivill/postgres-backup-local:${PG_VER:=17}
+              image: docker.io/prodrigestivill/postgres-backup-local:${PG_VER:=18}
               imagePullPolicy: IfNotPresent
               command:
                 - /backup.sh


### PR DESCRIPTION
Declarative offline in-place major upgrade. The operator stops every pod, runs pg_upgrade and re-creates the replicas; the Cluster keeps its name and its PVCs.

DO NOT MERGE until the apps are quiesced and the pre-upgrade backup has completed. Merging this is the upgrade. The apps must stay stopped through the smoke test, because that is what keeps the "restore, lose nothing" abort reachable.

serverName moves to pgcluster-default-v18 because pg_upgrade resets the timeline and assigns a new system ID, so the PG18 WAL stream is not continuous with the PG17 one. Both under a single B2 prefix would break a later restore. barmanObjectName keeps the &name anchor; only serverName becomes a literal. The new prefix starts empty, so an on-demand backup follows immediately.

PG_VER moves to 18 in the same commit because pg_dump 17 cannot dump from a PG18 server, which would silently break every pgdump CronJob to clonenas. The component default carries nine apps; litellm pins it explicitly and is moved with them. memini and immich keep their explicit 17 -- they are on pgvector-cluster, which stays on PostgreSQL 17 until phase 7. Rendering confirms 10 CronJobs on :18 and exactly those two on :17.

Rehearsed on pgcluster-green: 45s of downtime, data identical afterwards, and both Prisma apps verified against PostgreSQL 18.6 with real reads and writes.

Rollback: revert this commit ONLY while the upgrade job has not yet succeeded. pg_upgrade runs with --link and replaces the original PGDATA on success, so after that the abort is a restore of
pgcluster-default-pre-pg18, not an image revert. pgsql-cluster also remains as a warm PG17 copy until phase 5.

Refs: .agents/superpowers/plans/2026-08-13-pg17-to-pg18-upgrade.md


Claude-Session: https://claude.ai/code/session_01KCCNW3qRSZmuQnqDZ82t34