### PR TITLE
feat(cnpg): add pgvector-green to rehearse the vchord and PG18 jumps

### DIFF
--- a/kubernetes/apps/database/cnpg/ks.yaml
+++ b/kubernetes/apps/database/cnpg/ks.yaml
@@ -156,3 +156,32 @@ spec:
     namespace: flux-system
   targetNamespace: database
   wait: true
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cnpg-pgvector-green
+spec:
+  dependsOn:
+    - name: cnpg-operator
+    - name: cnpg-barman-cloud
+    # provides the pgvector-cluster ObjectStore this recovers from
+    - name: cnpg-pgvector-cluster
+    - name: openebs
+      namespace: openebs-system
+  interval: 1h
+  path: ./kubernetes/apps/database/cnpg/pgvector-green
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cnpg-secret
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  wait: true

--- a/kubernetes/apps/database/cnpg/pgvector-green/cluster.yaml
+++ b/kubernetes/apps/database/cnpg/pgvector-green/cluster.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: &name pgvector-green
+  annotations:
+    cnpg.io/skipEmptyWalArchiveCheck: "enabled"
+spec:
+  instances: 3
+  # renovate: datasource=docker depName=ghcr.io/tensorchord/cloudnative-vectorchord
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:17.5-0.4.2
+  primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: switchover
+  storage:
+    size: 10Gi
+    storageClass: openebs-hostpath
+
+  # Throwaway rehearsal clone of pgvector-cluster. It exists to answer two questions
+  # before production is touched at all:
+  #   1. does vchord survive 0.4.2 -> 1.1.1, and do the four vchordrq indexes need a rebuild
+  #   2. how long does the 17 -> 18 pg_upgrade take on this data
+  # Recovers from production's B2 prefix read-only and has NO plugins block, so it archives
+  # nowhere and cannot write into that prefix. Image must match production exactly -- a
+  # physical recovery cannot cross a major version or an extension ABI.
+  bootstrap:
+    recovery:
+      source: source
+
+  externalClusters:
+    - name: source
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          # read-only: production's prefix. Never written to.
+          barmanObjectName: pgvector-cluster
+          serverName: pgvector-cluster
+
+  superuserSecret:
+    name: cnpg-secret
+  enableSuperuserAccess: true
+  postgresql:
+    shared_preload_libraries: ["vchord.so"]
+    pg_hba: ["host all all 10.42.0.0/16 scram-sha-256"]
+    parameters:
+      max_connections: "100"
+      shared_buffers: 256MB
+      autovacuum_vacuum_scale_factor: "0.1"
+      autovacuum_analyze_scale_factor: "0.05"
+      autovacuum_vacuum_cost_limit: "1000"
+      effective_io_concurrency: "200"
+      random_page_cost: "1.2"
+      work_mem: 16MB
+  resources:
+    requests:
+      cpu: 200m
+      memory: 1Gi
+    limits:
+      memory: 2Gi
+  monitoring:
+    enablePodMonitor: true
+  # enablePDB replaces nodeMaintenanceWindow https://cloudnative-pg.io/documentation/1.26/kubernetes_upgrade/#pod-disruption-budgets
+  enablePDB: true
+  # Fix for non AWS backup https://github.com/cloudnative-pg/cloudnative-pg/issues/7715#issuecomment-2935582020
+  env:
+    - name: AWS_REQUEST_CHECKSUM_CALCULATION
+      value: when_required
+    - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+      value: when_required
+    - name: TZ
+      value: ${TIMEZONE:-UTC}

--- a/kubernetes/apps/database/cnpg/pgvector-green/kustomization.yaml
+++ b/kubernetes/apps/database/cnpg/pgvector-green/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cluster.yaml


### PR DESCRIPTION
Throwaway clone of pgvector-cluster. It exists to answer two questions before production is touched at all, and it is deleted once it has.

The plan rehearsed the 17 to 18 upgrade but did NOT rehearse the vchord bump -- Task 21 ran 0.4.2 to 1.1.1 straight on production. That is the riskier of the two. pgcluster-default carried only core contrib extensions, which is why its upgrade was uneventful; this cluster carries a third-party one, and a 0.x to 1.x jump is exactly where an extension can change its on-disk format.

Four vchordrq indexes are at stake: clip_index on smart_search and face_index on face_search in immich, idx_memories_vec and idx_memory_chunks_vec in memini. Whether ALTER EXTENSION vchord UPDATE carries them from 0.4.2 to 1.1.1, or whether they need REINDEX, is the thing this clone answers. Immich also validates its vchord version range on startup and refuses to run outside it.

Rehearsing before the rename rather than after also means a bad answer costs nothing: no production cutover has happened yet, so the finding can change the plan instead of interrupting it.

It recovers from pgvector-cluster's B2 prefix read-only and carries NO plugins block, so it archives nowhere and cannot write into that prefix. imageName matches production exactly -- a physical recovery cannot cross a major version or an extension ABI. Storage is 10Gi; the source is 254MB.

No app connects to it and nothing else references it.

Refs: .agents/superpowers/plans/2026-08-13-pg17-to-pg18-upgrade.md


Claude-Session: https://claude.ai/code/session_01KCCNW3qRSZmuQnqDZ82t34