### PR TITLE
fix(rustfs): Enable virtual-hosted-style S3 addressing

### DIFF
--- a/docs/context/networking.md
+++ b/docs/context/networking.md
@@ -86,4 +86,5 @@ The `gatus-sidecar` runs with `--auto-httproute --enable-httproute --enable-serv
 ## DNS
 
 - `external-dns` manages Cloudflare DNS records automatically from HTTPRoute annotations.
+- `external-dns` does **not** create wildcard records. `*.s3.${SECRET_DOMAIN}` (rustfs virtual-hosted-style S3 addressing) is a manual Cloudflare record, pointing at the same target as `s3.${SECRET_DOMAIN}`.
 - Internal DNS: CoreDNS + `unifi-dns` for `.internal` hostnames.

--- a/kubernetes/apps/default/rustfs/app/helmrelease.yaml
+++ b/kubernetes/apps/default/rustfs/app/helmrelease.yaml
@@ -97,7 +97,9 @@ spec:
       s3:
         annotations:
           gatus.home-operations.com/enabled: "false"
-        hostnames: ["${S3_SUBDOMAIN}.${SECRET_DOMAIN}"]
+        hostnames:
+          - "${S3_SUBDOMAIN}.${SECRET_DOMAIN}"
+          - "*.${S3_SUBDOMAIN}.${SECRET_DOMAIN}"
         parentRefs:
           - name: envoy-external
             namespace: network

--- a/kubernetes/apps/network/certificates/export/certificate.yaml
+++ b/kubernetes/apps/network/certificates/export/certificate.yaml
@@ -10,7 +10,7 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   commonName: "${SECRET_DOMAIN}"
-  dnsNames: ["${SECRET_DOMAIN}", "*.${SECRET_DOMAIN}"]
+  dnsNames: ["${SECRET_DOMAIN}", "*.${SECRET_DOMAIN}", "*.s3.${SECRET_DOMAIN}"]
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cert-manager.io/certificate_v1.json
 apiVersion: cert-manager.io/v1

--- a/kubernetes/apps/network/certificates/import/externalsecret.yaml
+++ b/kubernetes/apps/network/certificates/import/externalsecret.yaml
@@ -16,7 +16,7 @@ spec:
       type: kubernetes.io/tls
       metadata:
         annotations:
-          cert-manager.io/alt-names: "*.${SECRET_DOMAIN},${SECRET_DOMAIN}"
+          cert-manager.io/alt-names: "*.${SECRET_DOMAIN},${SECRET_DOMAIN},*.s3.${SECRET_DOMAIN}"
           cert-manager.io/certificate-name: ${SECRET_DOMAIN/./-}-production
           cert-manager.io/common-name: ${SECRET_DOMAIN}
           cert-manager.io/ip-sans: ""


### PR DESCRIPTION
Add a *.s3.<domain> wildcard to the rustfs S3 HTTPRoute hostname and
the t0m.co production cert (SAN + ESO alt-names mirror), so bucket
hostnames like <bucket>.s3.t0m.co route to the S3 listener and pass
TLS. The *.s3.<domain> DNS record is manual — external-dns does not
create wildcard records. Path-style s3.t0m.co is unchanged.
