### PR TITLE
fix(rustfs): includes towonel and unifi-dns resolve wildcard subdomain

### DIFF
--- a/kubernetes/apps/network/towonel-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/network/towonel-agent/app/helmrelease.yaml
@@ -14,6 +14,8 @@ spec:
       services:
         - hostname: "*.${SECRET_DOMAIN}"
           origin: &origin envoy-external.network.svc.cluster.local:443
+        - hostname: "*.s3.${SECRET_DOMAIN}"
+          origin: *origin
         - hostname: "*.${CEAPP_DOMAIN}"
           origin: *origin
         - hostname: "${CEAPP_DOMAIN}"

--- a/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
@@ -15,8 +15,8 @@ spec:
       name: webhook
       webhook:
         image:
-          repository: ghcr.io/kashalls/external-dns-unifi-webhook
-          tag: v0.9.0@sha256:22f4106f44a0b9ac3c97cf29bbfef93026c1164492152dc797a1d6dc86ddfbb5
+          repository: ghcr.io/home-operations/external-dns-unifi-webhook
+          tag: 0.10.12@sha256:5338b99662e2e15048b4e14b49e17279d384970fdcb3c29169f509f806f49cbe
         env:
           - name: UNIFI_HOST
             value: https://192.168.1.1
@@ -53,6 +53,9 @@ spec:
     domainFilters:
       - "${SECRET_DOMAIN}"
       - internal
+    # UDM cannot create a wildcard record and 500s in a loop. Cloudflare serves the public wildcard.
+    excludeDomains:
+      - "*.s3.${SECRET_DOMAIN}"
     serviceMonitor:
       enabled: true
     podAnnotations:


### PR DESCRIPTION
route virtual-hosted S3 and stop UDM wildcard 500 loop

unifi-dns: exclude `*.s3.${SECRET_DOMAIN}` from the UDM provider — dnsmasq
cannot create the wildcard record, so external-dns was 500-ing in a loop.
The Cloudflare instance still serves the public wildcard and the `s3` apex
is preserved for kometa. Move the webhook image to
home-operations/external-dns-unifi-webhook.

towonel-agent: tunnel the `*.s3` subdomain SNI to envoy-external so
bucket.s3.* requests reach rustfs.
