### PR TITLE
feat(cnpg): add pgcluster-vector replica, remove pgvector-green

### DIFF
--- a/kubernetes/apps/database/cnpg/ks.yaml
+++ b/kubernetes/apps/database/cnpg/ks.yaml
@@ -161,17 +161,18 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: cnpg-pgvector-green
+  name: cnpg-pgcluster-vector
 spec:
   dependsOn:
     - name: cnpg-operator
     - name: cnpg-barman-cloud
-    # provides the pgvector-cluster ObjectStore this recovers from
+    # cnpg-pgvector-cluster owns the pgvector-cluster ObjectStore this recovers from.
+    # Do not delete that Kustomization before promotion.
     - name: cnpg-pgvector-cluster
     - name: openebs
       namespace: openebs-system
   interval: 1h
-  path: ./kubernetes/apps/database/cnpg/pgvector-green
+  path: ./kubernetes/apps/database/cnpg/pgcluster-vector
   postBuild:
     substituteFrom:
       - kind: Secret

--- a/kubernetes/apps/database/cnpg/pgcluster-vector/cluster.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-vector/cluster.yaml
@@ -2,7 +2,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: &name pgvector-green
+  name: &name pgcluster-vector
   annotations:
     cnpg.io/skipEmptyWalArchiveCheck: "enabled"
 spec:
@@ -12,26 +12,29 @@ spec:
   primaryUpdateStrategy: unsupervised
   primaryUpdateMethod: switchover
   storage:
-    size: 10Gi
+    size: 20Gi
     storageClass: openebs-hostpath
 
-  # Throwaway rehearsal clone of pgvector-cluster. It exists to answer two questions
-  # before production is touched at all:
-  #   1. does vchord survive 0.4.2 -> 1.1.1, and do the four vchordrq indexes need a rebuild
-  #   2. how long does the 17 -> 18 pg_upgrade take on this data
-  # Recovers from production's B2 prefix read-only and has NO plugins block, so it archives
-  # nowhere and cannot write into that prefix. Image must match production exactly -- a
-  # physical recovery cannot cross a major version or an extension ABI.
+  # Blue/green rename of pgvector-cluster. A Cluster cannot be renamed, so this one
+  # bootstraps from blue's object store and then stays in continuous recovery, replaying
+  # blue's archived WAL until it is promoted.
+  # imageName must match blue exactly -- a physical replica cannot cross a major version
+  # or an extension ABI. vchord moves to 1.1.1 only after promotion, in its own commit.
   bootstrap:
     recovery:
-      source: source
+      source: blue
+
+  # Promotion (removing this block) is irreversible.
+  replica:
+    enabled: true
+    source: blue
 
   externalClusters:
-    - name: source
+    - name: blue
       plugin:
         name: barman-cloud.cloudnative-pg.io
         parameters:
-          # read-only: production's prefix. Never written to.
+          # read-only: the OLD cluster's prefix. Never written to.
           barmanObjectName: pgvector-cluster
           serverName: pgvector-cluster
 
@@ -68,3 +71,9 @@ spec:
       value: when_required
     - name: TZ
       value: ${TIMEZONE:-UTC}
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: *name
+        serverName: *name

--- a/kubernetes/apps/database/cnpg/pgcluster-vector/kustomization.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-vector/kustomization.yaml
@@ -1,6 +1,8 @@
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./cluster.yaml
+  - ./objectstore.yaml
+  - ./scheduledbackup.yaml
+  - ./service.yaml

--- a/kubernetes/apps/database/cnpg/pgcluster-vector/objectstore.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-vector/objectstore.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/barmancloud.cnpg.io/objectstore_v1.json
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: pgcluster-vector
+spec:
+  retentionPolicy: 7d
+  configuration:
+    destinationPath: s3://${AWS_CNPG_BUCKET}
+    endpointURL: https://${AWS_ENDPOINT}
+    s3Credentials:
+      accessKeyId:
+        name: cnpg-secret
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: cnpg-secret
+        key: AWS_SECRET_ACCESS_KEY
+    data:
+      compression: bzip2
+    wal:
+      compression: bzip2
+      maxParallel: 8

--- a/kubernetes/apps/database/cnpg/pgcluster-vector/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-vector/scheduledbackup.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: pgcluster-vector-barman
+spec:
+  cluster:
+    name: pgcluster-vector
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  # CNPG cron is 6-field (seconds first), not the 5-field Kubernetes CronJob format
+  schedule: "0 0 6 * * *"
+  # A replica cluster cannot take a base backup. Un-suspended at promotion.
+  suspend: true
+  immediate: true
+  backupOwnerReference: self

--- a/kubernetes/apps/database/cnpg/pgcluster-vector/service.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-vector/service.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/service_v1.json
+apiVersion: v1
+kind: Service
+metadata:
+  name: pgcluster-vector
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: "pgcluster-vector.${SECRET_DOMAIN}"
+spec:
+  type: ClusterIP
+  selector:
+    cnpg.io/cluster: pgcluster-vector
+    cnpg.io/instanceRole: primary
+  ports:
+    - name: postgres
+      port: 5432
+      protocol: TCP
+      targetPort: 5432


### PR DESCRIPTION
Starts the pgvector-cluster -> pgcluster-vector rename, and retires the rehearsal clone that made it safe to start.

pgcluster-vector is built as a standalone replica cluster (replica.enabled) bootstrapping from pgvector-cluster's B2 prefix and then replaying archived WAL continuously. It follows production until promoted, so the cutover is a promotion plus a CNPG_NAME repoint rather than a restore. imageName matches blue exactly at 17.5-0.4.2 -- a physical replica cannot cross a major version or an extension ABI, and vchord moves to 1.1.1 only after promotion, in its own commit. Its ScheduledBackup is suspended until then because a replica cannot take a base backup.

No app is repointed by this commit. pgvector-cluster keeps serving.

pgvector-green answered the two questions it was built for and is deleted.

  1. ALTER EXTENSION vchord UPDATE goes 0.4.2 to 1.1.1 in one step and reports success, the catalog moves to 1.1.1, and all four vchordrq indexes report indisvalid=true -- while every vector query fails with "deserialization: bad version number". The on-disk index format changed between 0.4.x and 1.x and PostgreSQL cannot see it. REINDEX INDEX CONCURRENTLY fixes all four in under a second each, with no table lock. Running that bump unrehearsed on production, as the plan had it, would have broken immich and memini search with every health signal green.

  2. pg_upgrade to 18.4-1.1.1 needs no second REINDEX. vchord stayed at 1.1.1, the indexes came through valid, and search worked untouched. 55s to serving. One rebuild for this migration, not two.

Green ran a single postgres container with no barman sidecar and no plugins block, so it never had a path to any bucket, and blue's recovery window was unchanged throughout.

Refs: .agents/superpowers/plans/2026-08-13-pg17-to-pg18-upgrade.md


Claude-Session: https://claude.ai/code/session_01KCCNW3qRSZmuQnqDZ82t34