### PR TITLE
feat(cnpg)!: promote pgcluster-vector and repoint immich and memini

### DIFF
--- a/docs/context/components.md
+++ b/docs/context/components.md
@@ -65,7 +65,7 @@ components:
 postBuild:
     substitute:
         APP: *app
-        CNPG_NAME: &postgresAppName pgcluster-default # or pgvector-cluster
+        CNPG_NAME: &postgresAppName pgcluster-default # or pgcluster-vector
 healthChecks:
     - apiVersion: &postgresVersion postgresql.cnpg.io/v1
       kind: &postgresKind Cluster
@@ -96,7 +96,7 @@ Creates three resources in the app's namespace:
 | `${APP}-initdb-secret` | ExternalSecret | `INIT_POSTGRES_*` vars for the init container                                       |
 | `${APP}-pg-backups`    | CronJob        | pgdump to NFS on clonenas, `5 */4 * * *`                                            |
 
-`PG_VER` (default `18`) selects the `postgres-backup-local` image tag for that CronJob — override it only if the app's cluster runs a different major version. `memini` and `immich` pin `17` because they are on `pgvector-cluster`, which is still PostgreSQL 17.
+`PG_VER` (default `18`) selects the `postgres-backup-local` image tag for that CronJob — override it only if the app's cluster runs a different major version. `memini` and `immich` pin `17` because they are on `pgcluster-vector`, which is still PostgreSQL 17.
 
 The component stops at credentials. The app's HelmRelease has to run the init container that creates the role and database:
 
@@ -112,7 +112,7 @@ initContainers:
                   name: "{{ .Release.Name }}-initdb-secret"
 ```
 
-`CNPG_NAME` picks the cluster: `pgcluster-default` for general apps, `pgvector-cluster` for apps needing vector search ([ADR-0011](../adr/0011-pgvector-cluster-split.md)). It defaults to `pgcluster-default` in the component (`${CNPG_NAME:=pgcluster-default}`) — but set it explicitly anyway, because the `healthChecks` block below needs the anchor. Both clusters live in the `database` namespace; `storage.md` says what each is for.
+`CNPG_NAME` picks the cluster: `pgcluster-default` for general apps, `pgcluster-vector` for apps needing vector search ([ADR-0011](../adr/0011-pgvector-cluster-split.md)). It defaults to `pgcluster-default` in the component (`${CNPG_NAME:=pgcluster-default}`) — but set it explicitly anyway, because the `healthChecks` block below needs the anchor. Both clusters live in the `database` namespace; `storage.md` says what each is for.
 
 The generated `host` is `{cluster}-rw…`, shared by every app on that cluster — apps read it from the Secret, they never compose it.
 

--- a/docs/context/storage.md
+++ b/docs/context/storage.md
@@ -2,7 +2,7 @@
 
 ## ⚠️ Gotchas & Interactions
 
-- **CNPG endpoints are named after the cluster, not the app:** the `host` key is `{cluster}-rw.database.svc.cluster.local` — `pgcluster-default-rw` or `pgvector-cluster-rw`, shared by every app on that cluster. Use the `host` key from `${APP}-pguser-secret` rather than composing a name. Never point an app at `-ro`; that is the read replica.
+- **CNPG endpoints are named after the cluster, not the app:** the `host` key is `{cluster}-rw.database.svc.cluster.local` — `pgcluster-default-rw` or `pgcluster-vector-rw`, shared by every app on that cluster. Use the `host` key from `${APP}-pguser-secret` rather than composing a name. Never point an app at `-ro`; that is the read replica.
 - **Ceph mutes four `AUTH_INSECURE_*` warnings on purpose:** Ceph Tentacle (v20) flags the older `aes` cephx cipher. Daemon keys (mon/mgr/osd) are rotated to `aes256k` via `security.cephx.daemon`, but CSI keys are pinned to `aes` because `aes256k` needs a host kernel of 7.0+ and the Talos nodes are below that. The remaining warnings cannot clear, so they are muted declaratively in `cephClusterSpec.healthCheck.muteHealthWarning`. Unmute — and drop `security.cephx.csi.keyType` — once the nodes reach kernel 7.0+.
 - **openebs-hostpath is node-local:** Data is tied to the node. A pod rescheduling to a different node loses access to its PVC.
 
@@ -32,7 +32,7 @@ Clusters in the `database` namespace ([ADR-0004](../adr/0004-cloudnativepg-for-p
 | Cluster             | Purpose                | Notes                                                           |
 | ------------------- | ---------------------- | --------------------------------------------------------------- |
 | `pgcluster-default` | All general apps       | Default                                                         |
-| `pgvector-cluster`  | Immich + pgvector apps | Shared cluster for apps needing vector search; adds vectorchord |
+| `pgcluster-vector`  | Immich + pgvector apps | Shared cluster for apps needing vector search; adds vectorchord |
 
 The PostgreSQL major version is not recorded here — it is whatever `imageName`
 says in each cluster's manifest under `kubernetes/apps/database/cnpg/`. Renovate

--- a/kubernetes/apps/ai/memini/ks.yaml
+++ b/kubernetes/apps/ai/memini/ks.yaml
@@ -10,7 +10,7 @@ spec:
   dependsOn:
     - name: secret-stores
       namespace: external-secrets
-    - name: cnpg-pgvector-cluster
+    - name: cnpg-pgcluster-vector
       namespace: database
     - name: llmkube
   interval: 1h
@@ -19,7 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      CNPG_NAME: &postgresAppName pgvector-cluster
+      CNPG_NAME: &postgresAppName pgcluster-vector
       PG_VER: "17"
     substituteFrom:
       - kind: Secret

--- a/kubernetes/apps/database/cnpg/pgcluster-vector/cluster.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-vector/cluster.yaml
@@ -15,29 +15,6 @@ spec:
     size: 20Gi
     storageClass: openebs-hostpath
 
-  # Blue/green rename of pgvector-cluster. A Cluster cannot be renamed, so this one
-  # bootstraps from blue's object store and then stays in continuous recovery, replaying
-  # blue's archived WAL until it is promoted.
-  # imageName must match blue exactly -- a physical replica cannot cross a major version
-  # or an extension ABI. vchord moves to 1.1.1 only after promotion, in its own commit.
-  bootstrap:
-    recovery:
-      source: blue
-
-  # Promotion (removing this block) is irreversible.
-  replica:
-    enabled: true
-    source: blue
-
-  externalClusters:
-    - name: blue
-      plugin:
-        name: barman-cloud.cloudnative-pg.io
-        parameters:
-          # read-only: the OLD cluster's prefix. Never written to.
-          barmanObjectName: pgvector-cluster
-          serverName: pgvector-cluster
-
   superuserSecret:
     name: cnpg-secret
   enableSuperuserAccess: true

--- a/kubernetes/apps/database/cnpg/pgcluster-vector/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-vector/scheduledbackup.yaml
@@ -11,7 +11,5 @@ spec:
     name: barman-cloud.cloudnative-pg.io
   # CNPG cron is 6-field (seconds first), not the 5-field Kubernetes CronJob format
   schedule: "0 0 6 * * *"
-  # A replica cluster cannot take a base backup. Un-suspended at promotion.
-  suspend: true
   immediate: true
   backupOwnerReference: self

--- a/kubernetes/apps/database/pgadmin/app/config/servers.json
+++ b/kubernetes/apps/database/pgadmin/app/config/servers.json
@@ -15,9 +15,9 @@
       "TunnelAuthentication": 0
     },
     "2": {
-      "Name": "pgvector-cluster",
+      "Name": "pgcluster-vector",
       "Group": "Servers",
-      "Host": "pgvector-cluster-rw.database.svc.cluster.local",
+      "Host": "pgcluster-vector-rw.database.svc.cluster.local",
       "Port": 5432,
       "MaintenanceDB": "postgres",
       "Username": "postgres",

--- a/kubernetes/apps/default/immich/ks.yaml
+++ b/kubernetes/apps/default/immich/ks.yaml
@@ -9,7 +9,7 @@ spec:
     - ../../../../components/cnpg
     # Uses separate app/horizontalpodautoscaler.yaml for immich-server
   dependsOn:
-    - name: cnpg-pgvector-cluster
+    - name: cnpg-pgcluster-vector
       namespace: database
     - name: dragonfly-cluster
       namespace: database
@@ -25,7 +25,7 @@ spec:
       APP: *app
       GATUS_SUBDOMAIN: img
       GATUS_PATH: /api/server/ping
-      CNPG_NAME: &postgresAppName pgvector-cluster
+      CNPG_NAME: &postgresAppName pgcluster-vector
       PG_VER: "17"
     substituteFrom:
       - kind: Secret


### PR DESCRIPTION
Completes the pgvector-cluster -> pgcluster-vector rename. The replica cluster is promoted to an independent primary and both consumers move to the new endpoint.

DO NOT MERGE until immich and memini are quiesced, pg_switch_wal() has run on pgvector-cluster and pgcluster-vector has replayed to that LSN. Merging early promotes the cluster while apps are still writing to blue, which is how issue #1211 silently lost writes.

Promotion is irreversible, so the rollback here is "point CNPG_NAME back at pgvector-cluster", not "re-enable replication". pgvector-cluster is left running and intact for that reason.

imageName stays at 17.5-0.4.2 and PG_VER stays 17 on both apps. This commit is the rename only -- vchord moves to 1.1.1 and the cluster moves to PostgreSQL 18 in later commits, one variable at a time.

Both apps also change dependsOn from cnpg-pgvector-cluster to cnpg-pgcluster-vector. The plan did not mention this and grepping only for CNPG_NAME would have missed it: leaving it would tie immich and memini to a Kustomization that is deleted after the soak.

pgadmin's servers.json stays a literal by design -- it is a UI bookmark list, not an app-to-cluster binding -- but its entry is renamed so it points at a cluster that exists.

Rehearsed: the vector quiesce list is correct as written. app.kubernetes.io/ name=immich catches both immich-server and immich-machine-learning, all three workloads are plain Helm rather than operator-owned, and only immich-server and memini ever hold a connection. immich-public-proxy has no pguser secret at all, and memini-embed/memini-rerank are llmkube inference services, so none of the three belongs in the list.

Refs: .agents/superpowers/plans/2026-08-13-pg17-to-pg18-upgrade.md


Claude-Session: https://claude.ai/code/session_01KCCNW3qRSZmuQnqDZ82t34