### PR TITLE
fix(rustfs): change group claim name

### DIFF
--- a/kubernetes/apps/default/rustfs/app/helmrelease.yaml
+++ b/kubernetes/apps/default/rustfs/app/helmrelease.yaml
@@ -33,7 +33,7 @@ spec:
               RUSTFS_IDENTITY_OPENID_REDIRECT_URI: "https://${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}/rustfs/admin/v3/oidc/callback/default"
               RUSTFS_IDENTITY_OPENID_REDIRECT_URI_DYNAMIC: "off"
               RUSTFS_IDENTITY_OPENID_SCOPES: "openid,profile,email,groups"
-              RUSTFS_IDENTITY_OPENID_CLAIM_NAME: "groups"
+              RUSTFS_IDENTITY_OPENID_GROUPS_CLAIM: "groups"
               RUSTFS_IDENTITY_OPENID_DISPLAY_NAME: "PocketID"
             envFrom:
               - secretRef:


### PR DESCRIPTION
RUSTFS_IDENTITY_OPENID_CLAIM_NAME is a MinIO name that rustfs does not use.
Changed it to RUSTFS_IDENTITY_OPENID_GROUPS_CLAIM
