### PR TITLE
feat(cnpg): bump vchord to 1.1.1 on pgcluster-vector

### DIFF
--- a/kubernetes/apps/database/cnpg/pgcluster-vector/cluster.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-vector/cluster.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   instances: 3
   # renovate: datasource=docker depName=ghcr.io/tensorchord/cloudnative-vectorchord
-  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:17.5-0.4.2
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:17.10-1.1.1
   primaryUpdateStrategy: unsupervised
   primaryUpdateMethod: switchover
   storage:


### PR DESCRIPTION
Rolling restart with a switchover, not a major upgrade: same PostgreSQL major, same distribution (both bookworm), so CNPG replaces the pods one at a time. Seconds of interruption per instance, no outage window.

This is deliberately its own commit, ahead of the PostgreSQL 18 jump, so only one thing can fail at a time.

AFTER MERGING, TWO STEPS MUST FOLLOW IMMEDIATELY. Vector search is broken between them.

  1. ALTER EXTENSION vchord UPDATE;   -- in immich and memini
  2. REINDEX INDEX CONCURRENTLY on all four vchordrq indexes

The REINDEX is not optional and its need is not detectable. Rehearsed on a clone: the ALTER takes 0.4.2 straight to 1.1.1 and reports success, the catalog moves to 1.1.1, and every vchordrq index still reports indisvalid=true and indisready=true -- while every vector query fails with "deserialization: bad version number; after upgrading VectorChord, please use REINDEX to rebuild the index". The on-disk index format changed between 0.4.x and 1.x and PostgreSQL cannot see it, so indisvalid is worthless here and the only honest check is running an actual ANN query.

Measured on the clone, all four rebuilt in under a second each (72kB to 16MB). CONCURRENTLY takes no table lock, so this needs no outage -- but it does need to happen now rather than later.

immich validates vchord 0.3 to 1.9 on startup, so 1.1.1 stays in range.

Refs: .agents/superpowers/plans/2026-08-13-pg17-to-pg18-upgrade.md


Claude-Session: https://claude.ai/code/session_01KCCNW3qRSZmuQnqDZ82t34