### PR TITLE
feat(cnpg)!: upgrade pgcluster-vector to PostgreSQL 18

### DIFF
--- a/docs/context/components.md
+++ b/docs/context/components.md
@@ -96,7 +96,7 @@ Creates three resources in the app's namespace:
 | `${APP}-initdb-secret` | ExternalSecret | `INIT_POSTGRES_*` vars for the init container                                       |
 | `${APP}-pg-backups`    | CronJob        | pgdump to NFS on clonenas, `5 */4 * * *`                                            |
 
-`PG_VER` (default `18`) selects the `postgres-backup-local` image tag for that CronJob — override it only if the app's cluster runs a different major version. `memini` and `immich` pin `17` because they are on `pgcluster-vector`, which is still PostgreSQL 17.
+`PG_VER` (default `18`) selects the `postgres-backup-local` image tag for that CronJob — override it only if the app's cluster runs a different major version.
 
 The component stops at credentials. The app's HelmRelease has to run the init container that creates the role and database:
 

--- a/kubernetes/apps/ai/memini/ks.yaml
+++ b/kubernetes/apps/ai/memini/ks.yaml
@@ -20,7 +20,7 @@ spec:
     substitute:
       APP: *app
       CNPG_NAME: &postgresAppName pgcluster-vector
-      PG_VER: "17"
+      PG_VER: "18"
     substituteFrom:
       - kind: Secret
         name: cluster-secrets

--- a/kubernetes/apps/database/cnpg/pgcluster-vector/cluster.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-vector/cluster.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   instances: 3
   # renovate: datasource=docker depName=ghcr.io/tensorchord/cloudnative-vectorchord
-  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:17.10-1.1.1
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:18.4-1.1.1
   primaryUpdateStrategy: unsupervised
   primaryUpdateMethod: switchover
   storage:
@@ -53,4 +53,7 @@ spec:
       isWALArchiver: true
       parameters:
         barmanObjectName: *name
-        serverName: *name
+        # pg_upgrade resets the timeline and assigns a new system ID, so the PG18
+        # WAL stream is not continuous with the PG17 one. Sharing a serverName
+        # would put two discontinuous streams under one prefix and break restore.
+        serverName: pgcluster-vector-v18

--- a/kubernetes/apps/default/immich/ks.yaml
+++ b/kubernetes/apps/default/immich/ks.yaml
@@ -26,7 +26,7 @@ spec:
       GATUS_SUBDOMAIN: img
       GATUS_PATH: /api/server/ping
       CNPG_NAME: &postgresAppName pgcluster-vector
-      PG_VER: "17"
+      PG_VER: "18"
     substituteFrom:
       - kind: Secret
         name: cluster-secrets


### PR DESCRIPTION
Declarative offline in-place major upgrade. The operator stops every pod, runs pg_upgrade and re-creates the replicas; the Cluster keeps its name and its PVCs. Both images are bookworm, which CNPG requires across a major upgrade.

DO NOT MERGE until immich and memini are quiesced and the pre-upgrade backup has completed. Merging this is the upgrade.

serverName moves to pgcluster-vector-v18 because pg_upgrade resets the timeline and assigns a new system ID, so the PG18 WAL stream is not continuous with the PG17 one. Both under a single B2 prefix would break a later restore. barmanObjectName keeps the &name anchor.

PG_VER moves to 18 on immich and memini, the last two apps still pinned to 17, because pg_dump 17 cannot dump from a PG18 server. All twelve pgdump CronJobs now render on :18 and components.md no longer needs its exception note.

Rehearsed on a clone already carrying vchord 1.1.1 with its indexes rebuilt: 55s to PG18 serving, vchord stayed at 1.1.1, all four vchordrq indexes came through valid, and ANN search returned hits with no intervention. pg_upgrade needs NO second REINDEX -- that rebuild was owed to the vchord jump, which is already done and soaked.

Rollback: revert ONLY while the upgrade job has not yet succeeded. pg_upgrade runs with --link and replaces the original PGDATA on success, so after that the abort is a restore of pgcluster-vector-pre-pg18. pgvector-cluster also remains as a warm PG17 copy.

Refs: .agents/superpowers/plans/2026-08-13-pg17-to-pg18-upgrade.md


Claude-Session: https://claude.ai/code/session_01KCCNW3qRSZmuQnqDZ82t34