### PR TITLE
feat(cnpg): mount vchord as an extension image on pgcluster-vector

### DIFF
--- a/kubernetes/apps/database/cnpg/pgcluster-vector/cluster.yaml
+++ b/kubernetes/apps/database/cnpg/pgcluster-vector/cluster.yaml
@@ -7,8 +7,11 @@ metadata:
     cnpg.io/skipEmptyWalArchiveCheck: "enabled"
 spec:
   instances: 3
-  # renovate: datasource=docker depName=ghcr.io/tensorchord/cloudnative-vectorchord
-  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:18.4-1.1.1
+  # standard-BOOKWORM, matching the bundled image this replaced (both pgdg12).
+  # A different Debian release would change glibc, and glibc owns text collation,
+  # so every text btree index would need a REINDEX before it could be trusted.
+  # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.6-standard-bookworm@sha256:cdb5c283a473507f7c597ea7e045d1a5e8efcbc4c5101aada013af9bd37ccc43
   primaryUpdateStrategy: unsupervised
   primaryUpdateMethod: switchover
   storage:
@@ -19,6 +22,18 @@ spec:
     name: cnpg-secret
   enableSuperuserAccess: true
   postgresql:
+    # vchord is mounted from its own OCI image rather than baked into the
+    # postgres image, so the two version independently. Requires the
+    # Kubernetes ImageVolume feature (1.33+) and CNPG 1.27+.
+    extensions:
+      - name: vchord
+        image:
+          # renovate: datasource=docker depName=ghcr.io/tensorchord/vchord-scratch
+          reference: ghcr.io/tensorchord/vchord-scratch:pg18-v1.1.1@sha256:bdea43bed2a414e21bbf71767bf6f0739747ac480b267b51772dc214ac28dcb3
+        dynamic_library_path:
+          - /usr/lib/postgresql/18/lib
+        extension_control_path:
+          - /usr/share/postgresql/18/
     shared_preload_libraries: ["vchord.so"]
     pg_hba: ["host all all 10.42.0.0/16 scram-sha-256"]
     parameters:


### PR DESCRIPTION
Replaces the bundled cloudnative-vectorchord image with the standard CNPG postgres image plus vchord mounted from its own OCI image, using spec.postgresql.extensions. PostgreSQL and vchord now version independently: neither needs the other's publisher to ship a matching combined tag.

Deliberately standard-BOOKWORM, not the standard-trixie the upstream example uses. Both this and the bundled image it replaces are pgdg12, so glibc does not move. glibc owns text collation, so a Debian release change would silently reorder every text btree index -- valid according to indisvalid, wrong in practice -- and require a REINDEX of all of them before results could be trusted. Trixie is the newer base and worth taking eventually, but as its own change with that rebuild planned, not folded in here.

Rolling restart with a switchover, not a major upgrade: same PostgreSQL 18, same distribution, 18.4 to 18.6 is a patch bump.

Tested on a throwaway clone recovered from this cluster's own PG18 backup before writing this. Postgres started with vchord.so preloaded from the mounted volume, reported PostgreSQL 18.6 on Debian 12, and vchord resolved at 1.1.1 in both databases. All four vchordrq indexes came through valid and both apps' searches ran through their indexes -- immich's clip_index on cosine ops with probes set, memini's idx_memories_vec on L2 ops without. The failure mode if the mount had been wrong is a cluster that will not start, which is loud rather than silent.

Both images are pinned by digest. Two images that move independently make a floating tag twice as surprising.

Refs: #3689, #3343


Claude-Session: https://claude.ai/code/session_01KCCNW3qRSZmuQnqDZ82t34