### PR TITLE
fix(ai): raise memini model memory to 4Gi

### DIFF
--- a/kubernetes/apps/ai/memini/app/resources/memini-embed.yaml
+++ b/kubernetes/apps/ai/memini/app/resources/memini-embed.yaml
@@ -53,7 +53,7 @@ spec:
   resources:
     gpu: 1
     cpu: 100m
-    memory: 2Gi
+    memory: 4Gi
   extraArgs:
     # Qwen3-Embedding uses last-token pooling with left padding;
     # --embedding + --pooling last exposes the OpenAI-compatible

--- a/kubernetes/apps/ai/memini/app/resources/memini-rerank.yaml
+++ b/kubernetes/apps/ai/memini/app/resources/memini-rerank.yaml
@@ -53,7 +53,7 @@ spec:
   resources:
     gpu: 1
     cpu: 100m
-    memory: 2Gi
+    memory: 4Gi
   extraArgs:
     # Qwen3-Reranker needs rank pooling; --reranking + --pooling rank exposes
     # the Cohere-style /v1/rerank endpoint memini calls.


### PR DESCRIPTION
LLMKube 0.9.25 sets memory.limits from spec.resources.memory (#1726);
before, 2Gi was request-only. The iGPU is a virtualized virtio-gpu
render node (Talos in a VM), so GPU-staged tensors are charged to the
container cgroup — the 2Gi limit OOMKilled llama-server during load
("intel: execbuf ENOMEM" was the last log before the kill).
