### PR TITLE
fix(ai): quantize memini KV cache to q8_0

### DIFF
--- a/kubernetes/apps/ai/memini/app/resources/memini-embed.yaml
+++ b/kubernetes/apps/ai/memini/app/resources/memini-embed.yaml
@@ -63,6 +63,10 @@ spec:
     - last
     - --cache-ram
     - "0"
+    - --cache-type-k
+    - q8_0
+    - --cache-type-v
+    - q8_0
     - --no-mmap
     - --sleep-idle-seconds
     - "300"

--- a/kubernetes/apps/ai/memini/app/resources/memini-rerank.yaml
+++ b/kubernetes/apps/ai/memini/app/resources/memini-rerank.yaml
@@ -63,6 +63,10 @@ spec:
     - --embedding
     - --cache-ram
     - "0"
+    - --cache-type-k
+    - q8_0
+    - --cache-type-v
+    - q8_0
     - --no-mmap
     - --sleep-idle-seconds
     - "300"


### PR DESCRIPTION
The 4Gi limit is still OOMKilled: pre-upgrade pods peaked at
5.8-6.7Gi working set. The weights are small (0.6B); the bloat is
the f16 KV cache (8192 ctx x 2 slots) staged through virtio-gpu
remoting, which is charged to the container cgroup. q8_0 KV drops
it ~75%, expected footprint ~3Gi under the existing 4Gi limit.
