### PR TITLE
fix(ai): right-size memini model memory limits

### DIFF
--- a/kubernetes/apps/ai/memini/app/resources/memini-embed.yaml
+++ b/kubernetes/apps/ai/memini/app/resources/memini-embed.yaml
@@ -53,7 +53,7 @@ spec:
   resources:
     gpu: 1
     cpu: 100m
-    memory: 4Gi
+    memory: 4.5Gi
   extraArgs:
     # Qwen3-Embedding uses last-token pooling with left padding;
     # --embedding + --pooling last exposes the OpenAI-compatible

--- a/kubernetes/apps/ai/memini/app/resources/memini-rerank.yaml
+++ b/kubernetes/apps/ai/memini/app/resources/memini-rerank.yaml
@@ -53,7 +53,7 @@ spec:
   resources:
     gpu: 1
     cpu: 100m
-    memory: 4Gi
+    memory: 6Gi
   extraArgs:
     # Qwen3-Reranker needs rank pooling; --reranking + --pooling rank exposes
     # the Cohere-style /v1/rerank endpoint memini calls.


### PR DESCRIPTION
LLMKube 0.9.25 turned resources.memory into a hard limit; both
workloads now run q8_0 KV. Measured footprints with the correct
models (embed Q8_0 609MiB, rerank Q4_K_M 378MiB, both verified
InSync by LLMKube): rerank steady ~3.7Gi, embed peaking just over
4Gi. Set embed 4.5Gi, rerank 6Gi for headroom.
