### PR TITLE
chore(memini): increase embed memory higher for saeftey

### DIFF
--- a/kubernetes/apps/ai/memini/app/resources/memini-embed.yaml
+++ b/kubernetes/apps/ai/memini/app/resources/memini-embed.yaml
@@ -53,7 +53,7 @@ spec:
   resources:
     gpu: 1
     cpu: 100m
-    memory: 4.5Gi
+    memory: 5Gi
   extraArgs:
     # Qwen3-Embedding uses last-token pooling with left padding;
     # --embedding + --pooling last exposes the OpenAI-compatible


### PR DESCRIPTION
4.27Gi is currently holding and at 95% of 4.5Gi setting
bumped to 5Gi to be safe.
