### PR TITLE
fix(ci): pin mise version and guard image-pull against fork PRs

### DIFF
--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -27,10 +27,14 @@ jobs:
           patterns: kubernetes/**/*
 
   extract:
-    if: ${{ needs.filter.outputs.changed-files != '[]' }}
+    if: >-
+      ${{
+        needs.filter.outputs.changed-files != '[]' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      }}
     needs: filter
     name: Image Pull - Extract Images
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.repository.name }}-runner
     permissions:
       contents: read
       id-token: write # GitHub OIDC token, consumed by the aKeyless jwt auth method
@@ -60,6 +64,7 @@ jobs:
       - name: Setup Mise - Flate
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          version: 2026.9.2 # 2026.9.3 error publishing upstream
           cache: false
           tool_versions: |
             github:home-operations/flate 0.4.8
@@ -97,6 +102,7 @@ jobs:
       - name: Setup Mise - Talos
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          version: 2026.9.2 # 2026.9.3 error publishing upstream
           cache: false
           tool_versions: |
             talosctl latest


### PR DESCRIPTION
- Pin jdx/mise-action `version` input on both Setup Mise steps
  (Flate, Talos) instead of relying on default `latest`, which can
  resolve to a release tag before its assets are published and
  404 on download (see jdx/mise-action#616)
- Add `github.event.pull_request.head.repo.full_name ==
  github.repository` guard to extract/pull job conditions so
  forked PRs can't trigger runs on the self-hosted runner
