### PR TITLE
fix(pairdrop): remove --no-dtls flag from coturn args

### DIFF
--- a/kubernetes/apps/default/pairdrop/app/helmrelease.yaml
+++ b/kubernetes/apps/default/pairdrop/app/helmrelease.yaml
@@ -66,7 +66,6 @@ spec:
               - --user=$(TURN_USER):$(TURN_PASSWORD)
               - --realm=${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}
               - --server-name=pairdrop
-              - --no-dtls
               - --no-tls
               - --no-cli
               - --no-multicast-peers


### PR DESCRIPTION
coturn 4.17.2 removed DTLS support, making --no-dtls an unrecognized
option. The coturn container crashed on startup
