### PR TITLE
fix(llama-cpp): remove --mmap/--no-mmap flags rejected by b10884+

### DIFF
--- a/kubernetes/apps/ai/litellm/app/llama-qwen.yaml
+++ b/kubernetes/apps/ai/litellm/app/llama-qwen.yaml
@@ -116,7 +116,7 @@ spec:
     - "0.0"
     - --repeat-penalty
     - "1.0"
-    - --mmap
+    # --mmap removed — b10884+ rejects it (https://github.com/ggml-org/llama.cpp/issues/11195)
     # preserve_thinking replays every prior turn's trace; with Qwen3.8's xhigh
     # default that compounds until the window is gone. Callers override per request.
     - --chat-template-kwargs

--- a/kubernetes/apps/ai/memini/app/resources/memini-embed.yaml
+++ b/kubernetes/apps/ai/memini/app/resources/memini-embed.yaml
@@ -67,7 +67,7 @@ spec:
     - q8_0
     - --cache-type-v
     - q8_0
-    - --no-mmap
+    # --mmap removed — b10884+ rejects it (https://github.com/ggml-org/llama.cpp/issues/11195)
     - --sleep-idle-seconds
     - "300"
     - --alias

--- a/kubernetes/apps/ai/memini/app/resources/memini-rerank.yaml
+++ b/kubernetes/apps/ai/memini/app/resources/memini-rerank.yaml
@@ -67,7 +67,7 @@ spec:
     - q8_0
     - --cache-type-v
     - q8_0
-    - --no-mmap
+    # --mmap removed — b10884+ rejects it (https://github.com/ggml-org/llama.cpp/issues/11195)
     - --sleep-idle-seconds
     - "300"
     - --alias


### PR DESCRIPTION
llama.cpp b10884 removed the --mmap/--no-mmap server flags.
llama-qwen passed --mmap, memini-embed/rerank passed --no-mmap —
all three CrashLoopBackOff with "error: invalid argument: --mmap".

Remove all three mmap flag lines. mmap behavior is now default-on
with no opt-out; the change is invisible for llama-qwen (it wanted
mmap) and acceptable for memini (Ceph-backed models still work,
just with OS-level page cache pressure instead of strict RAM-only).
