### PR TITLE
feat(mailflow): add to default ns for mail gateway

### DIFF
--- a/docs/context/apps.md
+++ b/docs/context/apps.md
@@ -47,6 +47,7 @@ Full list by namespace. The source of truth is `kubernetes/apps/`; the list belo
 - homepage _(dashboard)_ [oidc]
 - immich _(photos)_ [cnpg, oidc]
 - komga _(comics/manga)_ [kopiur, zeroscaler, oidc]
+- mailflow _(mail account syncer)_ [cnpg, oidc]
 - mealie _(recipes)_ [kopiur, cnpg, oidc]
 - obsidian-couchdb _(CouchDB for Obsidian LiveSync)_ [kopiur]
 - pairdrop _(airdrop alternative)_

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - ./homepage/ks.yaml
   - ./immich/ks.yaml
   - ./komga/ks.yaml
+  - ./mailflow/ks.yaml
   - ./mealie/ks.yaml
   - ./obsidian-couchdb/ks.yaml
   - ./pairdrop/ks.yaml

--- a/kubernetes/apps/default/mailflow/app/config/default.conf
+++ b/kubernetes/apps/default/mailflow/app/config/default.conf
@@ -1,0 +1,267 @@
+# Overrides the baked frontend/nginx.conf (no envsubst in the image).
+# Two diffs from upstream: resolver -> cluster DNS (10.43.0.10), server -> mailflow-api:3000.
+upstream mailflow_api {
+    zone mailflow_api 64k;
+    resolver 10.43.0.10 valid=10s ipv6=off;
+    resolver_timeout 5s;
+    server mailflow-api:3000 resolve;
+}
+
+server {
+    listen 443 ssl;
+    server_name _;
+
+    ssl_certificate     /etc/nginx/ssl/cert.pem;
+    ssl_certificate_key /etc/nginx/ssl/key.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache   shared:SSL:10m;
+    ssl_session_timeout 1d;
+    ssl_session_tickets off;
+
+    # Security headers
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+    add_header X-Content-Type-Options    "nosniff" always;
+    add_header X-Frame-Options           "SAMEORIGIN" always;
+    add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy        "camera=(), microphone=(), geolocation=()" always;
+    # CSP: tighten as needed. 'unsafe-inline' styles are required by the React
+    # app (inline style props). Email images load from arbitrary https origins.
+    add_header Content-Security-Policy   "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data: https:; img-src 'self' data: https: blob:; connect-src 'self' wss:; frame-src 'self'; object-src 'none'; base-uri 'self';" always;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    client_max_body_size 50m;
+
+    proxy_buffer_size       128k;
+    proxy_buffers           4 256k;
+    proxy_busy_buffers_size 256k;
+
+    # OAuth proxy
+    location /oauth/ {
+        proxy_pass         http://mailflow_api;
+        proxy_http_version 1.1;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto https;
+        proxy_read_timeout 30s;
+    }
+
+    # OIDC browser redirect flows (start + callback)
+    location /auth/oidc/ {
+        proxy_pass         http://mailflow_api;
+        proxy_http_version 1.1;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto https;
+        proxy_read_timeout 30s;
+    }
+
+    # Long-running API operations (rules run iterates all inbox messages via IMAP)
+    location = /api/rules/run {
+        proxy_pass         http://mailflow_api;
+        proxy_http_version 1.1;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto https;
+        proxy_read_timeout 300s;
+    }
+
+    # AI streaming endpoints — long timeout, no buffering (SSE)
+    location /api/ai/ {
+        proxy_pass             http://mailflow_api;
+        proxy_http_version     1.1;
+        proxy_set_header       Host $host;
+        proxy_set_header       X-Real-IP $remote_addr;
+        proxy_set_header       X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header       X-Forwarded-Proto https;
+        proxy_read_timeout     300s;
+        proxy_buffering        off;
+        proxy_cache            off;
+    }
+
+    # API proxy
+    location /api/ {
+        proxy_pass         http://mailflow_api;
+        proxy_http_version 1.1;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto https;
+        proxy_read_timeout 60s;
+    }
+
+    # WebSocket proxy
+    location /ws {
+        proxy_pass         http://mailflow_api;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto https;
+        proxy_read_timeout 86400s;
+    }
+
+    # SPA fallback — never cache HTML so browsers always get current JS filenames
+    location / {
+        try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-store" always;
+        # Re-declare security headers (add_header in child blocks overrides parent)
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options    "nosniff" always;
+        add_header X-Frame-Options           "SAMEORIGIN" always;
+        add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy        "camera=(), microphone=(), geolocation=()" always;
+        add_header Content-Security-Policy   "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data: https:; img-src 'self' data: https: blob:; connect-src 'self' wss:; frame-src 'self'; object-src 'none'; base-uri 'self';" always;
+    }
+
+    # Service worker must never be cached — it controls push notifications and needs
+    # to update immediately when deployed. Exact-match takes precedence over the
+    # regex below, so /sw.js bypasses the 1-year immutable rule.
+    location = /sw.js {
+        add_header Cache-Control "no-store" always;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options    "nosniff" always;
+        add_header X-Frame-Options           "SAMEORIGIN" always;
+        add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy        "camera=(), microphone=(), geolocation=()" always;
+        add_header Content-Security-Policy   "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data: https:; img-src 'self' data: https: blob:; connect-src 'self' wss:; frame-src 'self'; object-src 'none'; base-uri 'self';" always;
+    }
+
+    # Cache static assets — no security headers needed on immutable assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff2?)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}
+
+# HTTP server — serves the app directly on port 80.
+# Intended for deployments behind a reverse proxy that terminates TLS upstream.
+# When the upstream proxy sets X-Forwarded-Proto: https, Express marks the
+# connection as secure and issues Secure cookies as normal.
+server {
+    listen 80;
+    server_name _;
+
+    # Security headers — HSTS is intentionally omitted here; it must only be
+    # sent over HTTPS and belongs on the TLS-terminating proxy instead.
+    add_header X-Content-Type-Options    "nosniff" always;
+    add_header X-Frame-Options           "SAMEORIGIN" always;
+    add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy        "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy   "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data: https:; img-src 'self' data: https: blob:; connect-src 'self' wss: ws:; frame-src 'self'; object-src 'none'; base-uri 'self';" always;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    client_max_body_size 50m;
+
+    proxy_buffer_size       128k;
+    proxy_buffers           4 256k;
+    proxy_busy_buffers_size 256k;
+
+    # OAuth proxy
+    location /oauth/ {
+        proxy_pass         http://mailflow_api;
+        proxy_http_version 1.1;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_read_timeout 30s;
+    }
+
+    # OIDC browser redirect flows (start + callback)
+    location /auth/oidc/ {
+        proxy_pass         http://mailflow_api;
+        proxy_http_version 1.1;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_read_timeout 30s;
+    }
+
+    # Long-running API operations (rules run iterates all inbox messages via IMAP)
+    location = /api/rules/run {
+        proxy_pass         http://mailflow_api;
+        proxy_http_version 1.1;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_read_timeout 300s;
+    }
+
+    # AI streaming endpoints — long timeout, no buffering (SSE)
+    location /api/ai/ {
+        proxy_pass             http://mailflow_api;
+        proxy_http_version     1.1;
+        proxy_set_header       Host $host;
+        proxy_set_header       X-Real-IP $remote_addr;
+        proxy_set_header       X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header       X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_read_timeout     300s;
+        proxy_buffering        off;
+        proxy_cache            off;
+    }
+
+    # API proxy
+    location /api/ {
+        proxy_pass         http://mailflow_api;
+        proxy_http_version 1.1;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_read_timeout 60s;
+    }
+
+    # WebSocket proxy
+    location /ws {
+        proxy_pass         http://mailflow_api;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_read_timeout 86400s;
+    }
+
+    # SPA fallback — never cache HTML so browsers always get current JS filenames
+    location / {
+        try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-store" always;
+        # Re-declare security headers (add_header in child blocks overrides parent)
+        add_header X-Content-Type-Options    "nosniff" always;
+        add_header X-Frame-Options           "SAMEORIGIN" always;
+        add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy        "camera=(), microphone=(), geolocation=()" always;
+        add_header Content-Security-Policy   "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data: https:; img-src 'self' data: https: blob:; connect-src 'self' wss: ws:; frame-src 'self'; object-src 'none'; base-uri 'self';" always;
+    }
+
+    # Service worker must never be cached
+    location = /sw.js {
+        add_header Cache-Control "no-store" always;
+        add_header X-Content-Type-Options    "nosniff" always;
+        add_header X-Frame-Options           "SAMEORIGIN" always;
+        add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy        "camera=(), microphone=(), geolocation=()" always;
+        add_header Content-Security-Policy   "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data: https:; img-src 'self' data: https: blob:; connect-src 'self' wss: ws:; frame-src 'self'; object-src 'none'; base-uri 'self';" always;
+    }
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff2?)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}

--- a/kubernetes/apps/default/mailflow/app/externalsecret.yaml
+++ b/kubernetes/apps/default/mailflow/app/externalsecret.yaml
@@ -1,0 +1,54 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name mailflow-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless-secret-store
+  target:
+    name: *name
+    template:
+      data:
+        # MailFlow's aKeyless key (under /default/mailflow) must be named SESSION_SECRET
+        APP_URL: "https://${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}"
+        FRONTEND_URL: "https://${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}"
+        DB_HOST: "${CNPG_NAME:=pgcluster-default}-rw.database.svc.cluster.local"
+        DB_PORT: "5432"
+        DB_NAME: "${APP}"
+        DB_USER: "${APP}"
+        DB_PASSWORD: "{{ .${APP}_postgres_password }}"
+        REDIS_URL: "redis://dragonfly-cluster.database.svc.cluster.local:6379/8"
+        SESSION_SECRET: "{{ .SESSION_SECRET }}"
+        ENCRYPTION_KEY: "{{ .ENCRYPTION_KEY }}"
+        VAPID_PUBLIC_KEY: "{{ .VAPID_PUBLIC_KEY }}"
+        VAPID_PRIVATE_KEY: "{{ .VAPID_PRIVATE_KEY }}"
+        VAPID_SUBJECT: "{{ .VAPID_SUBJECT }}"
+  dataFrom:
+    - extract:
+        key: /default/mailflow
+    - extract:
+        key: /database/cnpg-users
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name "${APP}-pgpass"
+spec:
+  # Seeds the CNPG role password so it never has to be created by hand. The
+  # generator is stateless, so refreshInterval "0" is what pins the value.
+  refreshInterval: "0"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless-secret-store
+  target:
+    name: *name
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: password32

--- a/kubernetes/apps/default/mailflow/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mailflow/app/helmrelease.yaml
@@ -84,7 +84,6 @@ spec:
               repository: ghcr.io/maathimself/mailflow-frontend
               tag: 3.3.0@sha256:141ad791641380e3d2a21b23f54aef23a4d48d0185959464596b9cfbab4c3e8e
             env:
-              BACKEND_URL: "{{ .Release.Name }}-web:3000"
               APP_HTTP_PORT: &webPort 80
             resources:
               requests:

--- a/kubernetes/apps/default/mailflow/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mailflow/app/helmrelease.yaml
@@ -1,0 +1,158 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app mailflow
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    controllers:
+      api:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        strategy: RollingUpdate
+        initContainers:
+          # Sizing the DB after backfill (psql against CNPG cluster pgcluster-default, ns database):
+          #   SELECT pg_size_pretty(pg_total_relation_size('messages'));  -- table + all its indexes
+          #   SELECT count(*), pg_size_pretty(sum(length(coalesce(body_text,'')))) FROM messages;  -- body footprint
+          01-init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18.6.0@sha256:b6d3af974df781c673d37e49bdddfa14a6f5be28b18d2cb7713f0449bea4057b
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-initdb-secret"
+            securityContext: &initSec
+              runAsNonRoot: false
+              runAsUser: 0
+              runAsGroup: 0
+              readOnlyRootFilesystem: false
+              allowPrivilegeEscalation: true
+        containers:
+          app:
+            image:
+              repository: ghcr.io/maathimself/mailflow-backend
+              tag: 3.3.0@sha256:6aadb04ce8efcbaf404704eec84c280095f8fcf880da0bb6d32ff606102ad157
+            env:
+              NODE_ENV: production
+              PORT: &apiPort 3000
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+              - secretRef:
+                  name: "{{ .Release.Name }}-oidc-secret"
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec: &probeSpec
+                  httpGet:
+                    path: ${GATUS_PATH}
+                    port: *apiPort
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                <<: *probes
+                spec:
+                  <<: *probeSpec
+                  periodSeconds: 10
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext: &sec
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: [ALL] }
+      web:
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/maathimself/mailflow-frontend
+              tag: 3.3.0@sha256:141ad791641380e3d2a21b23f54aef23a4d48d0185959464596b9cfbab4c3e8e
+            env:
+              BACKEND_URL: "{{ .Release.Name }}-web:3000"
+              APP_HTTP_PORT: &webPort 80
+            resources:
+              requests:
+                cpu: 20m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec: &probeSpec
+                  httpGet:
+                    path: /
+                    port: *webPort
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                <<: *probes
+                spec:
+                  <<: *probeSpec
+                  periodSeconds: 10
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              <<: *sec
+              readOnlyRootFilesystem: false
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      web:
+        controller: web
+        ports:
+          http:
+            port: *webPort
+      api:
+        controller: api
+        ports:
+          http:
+            port: *apiPort
+    route:
+      web:
+        hostnames: ["${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: web
+                port: *webPort
+    persistence:
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+      nginx-cache:
+        type: emptyDir
+        advancedMounts:
+          web:
+            app:
+              - path: /var/cache/nginx
+              - path: /var/run

--- a/kubernetes/apps/default/mailflow/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mailflow/app/helmrelease.yaml
@@ -112,9 +112,7 @@ spec:
                 spec:
                   failureThreshold: 30
                   periodSeconds: 10
-            securityContext:
-              <<: *sec
-              readOnlyRootFilesystem: false
+            securityContext: *initSec
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -155,3 +153,12 @@ spec:
             app:
               - path: /var/cache/nginx
               - path: /var/run
+      nginx-conf:
+        type: configMap
+        name: mailflow-nginx
+        advancedMounts:
+          web:
+            app:
+              - path: /etc/nginx/conf.d/default.conf
+                subPath: default.conf
+                readOnly: true

--- a/kubernetes/apps/default/mailflow/app/kustomization.yaml
+++ b/kubernetes/apps/default/mailflow/app/kustomization.yaml
@@ -8,3 +8,9 @@ resources:
   - ./ocirepository.yaml
   - ./pocketidoidcclient.yaml
   - ./pushsecret.yaml
+configMapGenerator:
+  - name: mailflow-nginx
+    files:
+      - ./config/default.conf
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/default/mailflow/app/kustomization.yaml
+++ b/kubernetes/apps/default/mailflow/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./pocketidoidcclient.yaml
+  - ./pushsecret.yaml

--- a/kubernetes/apps/default/mailflow/app/ocirepository.yaml
+++ b/kubernetes/apps/default/mailflow/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: &app mailflow
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/mailflow/app/pocketidoidcclient.yaml
+++ b/kubernetes/apps/default/mailflow/app/pocketidoidcclient.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/pocketid.internal/pocketidoidcclient_v1alpha1.json
+apiVersion: pocketid.internal/v1alpha1
+kind: PocketIDOIDCClient
+metadata:
+  name: mailflow
+spec:
+  name: MailFlow
+  # TODO: verify MailFlow's real OIDC callback path (routed through the frontend).
+  callbackUrls:
+    - "https://${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}/api/auth/callback"
+  launchUrl: "https://${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}/"
+  pkceEnabled: false
+  allowedUserGroups:
+    - name: id-admin
+      namespace: security
+    - name: id-family
+      namespace: security
+  secret:
+    enabled: true
+    name: mailflow-oidc-secret
+    keys:
+      # TODO: rename to the env vars the MailFlow backend actually expects
+      clientID: MAILFLOW_OIDC_CLIENT_ID
+      clientSecret: MAILFLOW_OIDC_CLIENT_SECRET
+      issuerUrl: MAILFLOW_OIDC_ISSUER_URL

--- a/kubernetes/apps/default/mailflow/app/pushsecret.yaml
+++ b/kubernetes/apps/default/mailflow/app/pushsecret.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/pushsecret_v1alpha1.json
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: &name mailflow-oidc-secret
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: akeyless-secret-store
+  selector:
+    secret:
+      name: *name
+  data:
+    - match:
+        secretKey: MAILFLOW_OIDC_CLIENT_ID
+        remoteRef:
+          remoteKey: /security/pocket-id-clients
+          property: MAILFLOW_OIDC_CLIENT_ID
+    - match:
+        secretKey: MAILFLOW_OIDC_CLIENT_SECRET
+        remoteRef:
+          remoteKey: /security/pocket-id-clients
+          property: MAILFLOW_OIDC_CLIENT_SECRET
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/pushsecret_v1alpha1.json
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: &name "${APP}-pgpass"
+spec:
+  refreshInterval: 1h
+  # IfNotExists makes aKeyless the source of truth after the first write
+  updatePolicy: IfNotExists
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: akeyless-secret-store
+  selector:
+    secret:
+      name: *name
+  data:
+    - match:
+        secretKey: password
+        remoteRef:
+          remoteKey: /database/cnpg-users
+          property: ${APP}_postgres_password

--- a/kubernetes/apps/default/mailflow/ks.yaml
+++ b/kubernetes/apps/default/mailflow/ks.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mailflow
+spec:
+  components:
+    - ../../../../components/cnpg
+  dependsOn:
+    - name: secret-stores
+      namespace: external-secrets
+    - name: cnpg-pgcluster-default
+      namespace: database
+    - name: pocket-id
+      namespace: security
+  interval: 1h
+  retryInterval: 5m
+  path: ./kubernetes/apps/default/mailflow/app
+  postBuild:
+    substitute:
+      APP: *app
+      GATUS_SUBDOMAIN: mail
+      GATUS_PATH: /api/health
+      CNPG_NAME: &postgresAppName pgcluster-default
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  healthChecks:
+    - apiVersion: &postgresVersion postgresql.cnpg.io/v1
+      kind: &postgresKind Cluster
+      name: *postgresAppName
+      namespace: database
+  healthCheckExprs:
+    - apiVersion: *postgresVersion
+      kind: *postgresKind
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false


### PR DESCRIPTION
Add mailflow (mail account syncer) to default namespace

Two-controller app-template: frontend (nginx SPA, proxies /api) +
backend (Node API) on envoy-internal at mail.<domain>.

- Postgres via CNPG pgcluster-default (seeded password + barman backups)
- Redis via shared Dragonfly, DB 8
- Secrets via ExternalSecret (aKeyless /default/mailflow) + seeded pgpass
- Auth: native OIDC via pocket-id (callback path + backend env var
  names are TODO pending MailFlow docs; .env lists no OIDC vars)
