### PR TITLE
fix(mailflow): resolve mailflow-api via FQDN in nginx upstream

### DIFF
--- a/kubernetes/apps/default/mailflow/app/config/default.conf
+++ b/kubernetes/apps/default/mailflow/app/config/default.conf
@@ -1,10 +1,12 @@
 # Overrides the baked frontend/nginx.conf (no envsubst in the image).
-# Two diffs from upstream: resolver -> cluster DNS (10.43.0.10), server -> mailflow-api:3000.
+# Two diffs from upstream: resolver -> cluster DNS (10.43.0.10), server -> FQDN.
+# The FQDN is required: nginx's `resolver` ignores /etc/resolv.conf search domains,
+# so the short name `mailflow-api` never expands and returns NXDOMAIN.
 upstream mailflow_api {
     zone mailflow_api 64k;
     resolver 10.43.0.10 valid=10s ipv6=off;
     resolver_timeout 5s;
-    server mailflow-api:3000 resolve;
+    server mailflow-api.default.svc.cluster.local:3000 resolve;
 }
 
 server {

--- a/kubernetes/apps/default/mailflow/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mailflow/app/helmrelease.yaml
@@ -77,6 +77,8 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: [ALL] }
       web:
+        annotations:
+          reloader.stakater.com/auto: "true"
         strategy: RollingUpdate
         containers:
           app:


### PR DESCRIPTION
nginx's `resolver` sends the name verbatim and ignores the pod's
/etc/resolv.conf search domains, so the short name `mailflow-api`
resolves to NXDOMAIN and every proxied request (/api, /ws, /oauth,
/auth) fails with "mailflow-api could not be resolved". Use the fully
qualified name mailflow-api.default.svc.cluster.local.
