### PR TITLE
feat(memini): spread embed and rerank InferenceServices across nodes

### DIFF
--- a/kubernetes/apps/ai/memini/app/resources/memini-embed.yaml
+++ b/kubernetes/apps/ai/memini/app/resources/memini-embed.yaml
@@ -37,6 +37,18 @@ spec:
           - matchExpressions:
               - key: extensions.talos.dev/i915
                 operator: Exists
+  # Soft spread: prefer memini-embed and memini-rerank on different nodes, but
+  # don't block scheduling if only one is available. 3 control-plane nodes
+  # expose i915 / dri-render; ai3090 is NVIDIA-only and excluded by affinity.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchExpressions:
+          - key: app
+            operator: In
+            values: [memini-embed, memini-rerank]
   podSecurityContext:
     # 102 = curlimages/curl curl_group GID; makes the /models emptyDir
     # writable by the model-downloader init container (we override the

--- a/kubernetes/apps/ai/memini/app/resources/memini-rerank.yaml
+++ b/kubernetes/apps/ai/memini/app/resources/memini-rerank.yaml
@@ -37,6 +37,18 @@ spec:
           - matchExpressions:
               - key: extensions.talos.dev/i915
                 operator: Exists
+  # Soft spread: prefer memini-embed and memini-rerank on different nodes, but
+  # don't block scheduling if only one is available. 3 control-plane nodes
+  # expose i915 / dri-render; ai3090 is NVIDIA-only and excluded by affinity.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchExpressions:
+          - key: app
+            operator: In
+            values: [memini-embed, memini-rerank]
   podSecurityContext:
     # 102 = curlimages/curl curl_group GID; makes the /models emptyDir
     # writable by the model-downloader init container (we override the


### PR DESCRIPTION
Both memini-embed and memini-rerank have nodeAffinity extensions.talos.dev/i915
and nodeSelector topology.kubernetes.io/zone=m, so they are eligible on all
three control-plane nodes (each advertises 10x kernel.org/dri-render via the
Talos Intel GPU device plugin; ai3090 is NVIDIA-only and excluded). They
currently both land on k8s-3 by coincidence.

Add a soft topologySpreadConstraint (maxSkew: 1, whenUnsatisfiable:
ScheduleAnyway, topologyKey: kubernetes.io/hostname) on each InferenceService,
keyed on the union of their pod labels (app in (memini-embed, memini-rerank))
so the scheduler counts each pod against the other and prefers a different
hostname for each. ScheduleAnyway guarantees neither pod is stranded during
single-node maintenance; the spread only takes effect on the next placement
decision, which the recurring memini-embed OOMs will trigger naturally.
